### PR TITLE
docs: add M0 roadmap, plan, and billing contract

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,8 +38,6 @@ coverage/
 
 tsconfig.local.json
 
-docs/
-
 /repos
 
 scripts/output/

--- a/docs/contracts/billing.md
+++ b/docs/contracts/billing.md
@@ -1,0 +1,264 @@
+# `billing.*` oRPC 契约 (v1)
+
+> **Audience:** Read Frog 后端团队（`read-frog-monorepo` / `@read-frog/api-contract`）
+> **Consumer:** 浏览器扩展仓 `mengxi-ream/read-frog`（本文件所在仓的 fork）
+> **Status:** Draft — 实施前以本文档为准；实施过程中若发现不合理，以 PR 修订本文件为准。
+> **Owner (extension side):** @iannoying / 本文档随 M0 PR 合入
+> **Last updated:** 2026-04-20
+
+---
+
+## 1. 设计目标
+
+1. **扩展端无状态**：所有订阅/配额状态以后端为准，扩展只做 30s-ish 本地缓存 + 离线降级。
+2. **失败安全**：任何 billing 接口故障必须降级到 **Free tier**，不允许"降级到 Pro"。
+3. **幂等**：`consumeQuota` 因网络重试可能被调用多次 —— 支持 `request_id` 幂等键。
+4. **可观测**：所有 billing 接口接入后端标准日志 + PostHog `billing_*` 事件。
+
+---
+
+## 2. 认证与会话
+
+- 所有 `billing.*` 接口 **要求已登录**（better-auth session cookie）。
+- 扩展端通过 `src/utils/auth/auth-client.ts` 的 `authClient` 维护 session；所有 oRPC 请求带 `credentials: "include"` + `x-orpc-source: extension` header（见 `src/utils/orpc/client.ts:9-14`）。
+- 未登录调用任意 `billing.*` → 后端返回 oRPC 错误码 `UNAUTHORIZED` (HTTP 401)。扩展端应 catch 并回退到 `FREE_ENTITLEMENTS`。
+
+---
+
+## 3. 数据模型
+
+### 3.1 `Entitlements`
+
+与扩展仓 `src/types/entitlements.ts` 中的 `EntitlementsSchema` **逐字节一致**。后端序列化时必须产出与下面 zod schema 能 parse 的 JSON。
+
+```ts
+const FeatureKey = z.enum([
+  'pdf_translate',                  // PDF 双语翻译 + 下载
+  'input_translate_unlimited',      // 输入框翻译无限次
+  'vocab_unlimited',                // 生词本无限条
+  'vocab_cloud_sync',               // 生词本云同步
+  'ai_translate_pool',              // 共享 AI 翻译配额池（OpenAI/Claude 走后端 key）
+  'subtitle_platforms_extended',    // Netflix/B站/X 等非 YouTube 字幕
+  'enterprise_glossary_share',      // 企业版共享术语表
+])
+
+const QuotaBucketSchema = z.object({
+  used: z.number().int().nonnegative(),
+  limit: z.number().int().nonnegative(),
+})
+
+const EntitlementsSchema = z.object({
+  tier: z.enum(['free', 'pro', 'enterprise']),
+  features: z.array(FeatureKey),
+  quota: z.record(z.string(), QuotaBucketSchema),
+  expiresAt: z.string().datetime().nullable(),
+})
+```
+
+**字段约定：**
+- `tier`：订阅层。`free` 始终可用；`pro` 有 `expiresAt`；`enterprise` 可为 `null`（座席制，后端自行续期）。
+- `features`：当前层级**已生效**的 feature list。`free` 下通常为空数组。
+- `quota`：配额桶字典，key 见 §3.2。每个桶返回本账单周期的 `used` / `limit`。
+- `expiresAt`：ISO 8601。若 `Date.parse(expiresAt) < now`，扩展端视为过期，降级为 Free。
+
+**禁止**：在同一响应内返回 `tier: 'pro'` 但 `features` 全空 —— 这会让扩展无法判断后端是"未实装"还是"确实没权益"。
+
+### 3.2 `QuotaBucket` keys（初版）
+
+| Key | 单位 | Free 上限 | Pro 上限 | 补充 |
+|-----|------|----------|---------|------|
+| `input_translate_daily`   | 次/天  | 50    | null (无限) | 自然日 UTC 重置 |
+| `pdf_translate_daily`     | 页/天  | 50    | null        | 自然日 UTC 重置 |
+| `vocab_count`             | 条     | 100   | null        | 生命周期累计 |
+| `ai_translate_monthly`    | 次/月  | 0     | 50_000      | 自然月 UTC 重置，仅 Pro 可用 |
+
+> **`null` 或字段缺失** 视为"无限制"。扩展端 `hasFeature / quota` 检查需同时允许这两种表达。
+
+### 3.3 `RequestId`
+
+`consumeQuota` 必须携带 `request_id: string`（扩展端用 `crypto.randomUUID()`）。后端以 `(userId, request_id)` 作幂等键，TTL 24h。
+
+---
+
+## 4. Procedures
+
+### 4.1 `billing.getEntitlements`
+
+| 项 | 值 |
+|----|----|
+| Auth | Required |
+| Input | `{}` |
+| Output | `Entitlements` |
+| Cache-Control | `private, max-age=30` |
+| Idempotent | Yes |
+| Rate limit | 60 req / min / user |
+
+**错误：**
+| oRPC code | HTTP | 语义 |
+|-----------|------|------|
+| `UNAUTHORIZED` | 401 | 未登录 / session 过期 |
+| `INTERNAL_SERVER_ERROR` | 500 | 不可恢复 |
+
+**扩展端行为：**
+- 200 → 写入 Dexie `entitlements_cache` + Jotai atom
+- 401 → 触发重新登录 UI；降级 Free
+- 5xx / 网络错误 → 读 Dexie 缓存；若无则 Free
+
+---
+
+### 4.2 `billing.consumeQuota`
+
+扣减指定桶的配额，原子操作。扩展在使用 Pro 功能**之前**调用，后端扣减后返回剩余额度。
+
+| 项 | 值 |
+|----|----|
+| Auth | Required |
+| Input | `{ bucket: string, amount: number, request_id: string }` |
+| Output | `{ bucket: string, remaining: number \| null, reset_at: string \| null }` |
+| Idempotent | **必须**（按 `request_id`） |
+| Rate limit | 300 req / min / user |
+
+**输入校验：**
+- `bucket` 必须在 §3.2 枚举内
+- `amount >= 1`
+- `request_id` 形如 UUID v4
+
+**错误：**
+| oRPC code | HTTP | 语义 |
+|-----------|------|------|
+| `UNAUTHORIZED` | 401 | 同上 |
+| `BAD_REQUEST` | 400 | bucket 未知 / amount 不合法 |
+| `QUOTA_EXCEEDED` | 402 | 额度不足，不扣减 |
+| `FORBIDDEN` | 403 | Free 用户访问仅 Pro 桶 |
+
+**幂等契约：**
+- 同 `(userId, request_id)` 第 2 次及以后调用，**不再扣减**，返回与第 1 次完全一致的响应（包括错误）。
+- TTL 24h。
+
+**扩展端行为：**
+- 成功 → 更新本地 atom 中的 `quota.<bucket>`
+- `QUOTA_EXCEEDED` → 弹 `<UpgradeDialog>`
+- 网络错误 → **不** retry（已 consumed 风险），直接报错给用户
+
+---
+
+### 4.3 `billing.createCheckoutSession`
+
+生成 Stripe Checkout 会话。扩展打开返回的 `url` 在新标签完成支付。
+
+| 项 | 值 |
+|----|----|
+| Auth | Required |
+| Input | `{ plan: 'pro_monthly' \| 'pro_yearly', successUrl: string, cancelUrl: string }` |
+| Output | `{ url: string }` |
+| Idempotent | 幂等可选（建议按 `userId + plan + 15min 窗口` 去重） |
+| Rate limit | 10 req / min / user |
+
+**输入约束：**
+- `successUrl` / `cancelUrl` 必须是 `https://readfrog.app/*` 或 `chrome-extension://*`，避免 open-redirect。后端白名单校验。
+
+**错误：**
+| oRPC code | HTTP | 语义 |
+|-----------|------|------|
+| `UNAUTHORIZED` | 401 |  |
+| `BAD_REQUEST` | 400 | plan/URL 不合法 |
+| `PRECONDITION_FAILED` | 412 | 用户已持有活跃 Pro 订阅（改走 `createPortalSession`） |
+
+---
+
+### 4.4 `billing.createPortalSession`
+
+生成 Stripe Customer Portal 链接，已订阅用户去管理/取消。
+
+| 项 | 值 |
+|----|----|
+| Auth | Required |
+| Input | `{}` |
+| Output | `{ url: string }` |
+| Rate limit | 10 req / min / user |
+
+**错误：**
+- `UNAUTHORIZED` / `PRECONDITION_FAILED`（未订阅用户调用）
+
+---
+
+## 5. Stripe Webhook（后端内部，扩展不参与）
+
+后端需在 `/api/stripe/webhook` 处理以下事件，并在处理成功后写 `user_entitlements` 表。每条事件**必须按 `event.id` 幂等**（TTL 30 天）。
+
+| Stripe 事件 | 行为 |
+|-------------|------|
+| `checkout.session.completed` | 创建/激活订阅 → 写入 `tier=pro`, `features`, `expiresAt` |
+| `customer.subscription.updated` | 续费、plan 变更 → 更新 `expiresAt` / `features` |
+| `customer.subscription.deleted` | 立即到期 → `tier=free`, 清空 Pro `features` |
+| `invoice.payment_failed` | **7 天宽限期**：保留 `tier=pro` 但加 flag `in_grace_period`（扩展端可用 `quota` 或单独字段展示 banner） |
+| `invoice.payment_succeeded` | 清除宽限期 flag |
+
+**签名校验**：所有 webhook 必须用 `STRIPE_WEBHOOK_SECRET` 验证 `Stripe-Signature` header。校验失败直接 400，不重试、不落库。
+
+**关键变量**
+- `STRIPE_SECRET_KEY` / `STRIPE_WEBHOOK_SECRET`：仅后端持有，严禁出现在扩展 build。本扩展的 `check-api-key-env` Vite 插件会拦截 `WXT_*_API_KEY` 泄漏，但最终 review 必须人肉确认。
+
+---
+
+## 6. 观测与日志
+
+### 6.1 结构化日志（后端）
+
+每次 `billing.*` 调用：
+
+```json
+{
+  "event": "billing.getEntitlements",
+  "user_id": "u_xxx",
+  "tier": "pro",
+  "latency_ms": 42,
+  "outcome": "success" | "quota_exceeded" | "error",
+  "request_id": "uuid-or-null"
+}
+```
+
+### 6.2 PostHog 事件
+
+- `billing_quota_consumed` props: `bucket`, `amount`, `remaining`, `tier`
+- `billing_quota_exceeded` props: `bucket`, `tier`
+- `billing_checkout_started` props: `plan`
+- `billing_checkout_completed` props: `plan`, `cents`
+- `billing_subscription_cancelled` props: `tier_before`
+
+扩展端与后端**可能双方都上报**（确保至少一端有）；用 `$insert_id = request_id` 做去重。
+
+---
+
+## 7. 版本演进
+
+- 本契约标为 v1。扩展端 `src/types/entitlements.ts` 在任何破坏性变更时同步 bump。
+- 增加新 `FeatureKey` / `QuotaBucket` key 为**非破坏性**，后端可先上线。扩展端老版本会忽略未知字段。
+- 移除 `FeatureKey` / 改字段类型为**破坏性**，需：
+  1. 契约 v2 草稿 PR
+  2. 扩展仓 PR 同步 schema
+  3. 后端灰度切换
+
+---
+
+## 8. 扩展端契约消费 checklist（交叉验证）
+
+后端实现完以下可供扩展联调：
+
+- [ ] `billing.getEntitlements` 返回 Free/Pro 两种账号
+- [ ] `billing.consumeQuota` 幂等（同 request_id 调两次返回一致）
+- [ ] `billing.consumeQuota` Free 账号调 Pro 桶返回 403
+- [ ] `billing.createCheckoutSession` 返回有效 Stripe URL
+- [ ] webhook `checkout.session.completed` 之后 30s 内 `getEntitlements` 反映为 Pro
+- [ ] webhook `customer.subscription.deleted` 后反映为 Free
+- [ ] webhook `invoice.payment_failed` 进入 7 天宽限
+
+扩展端 M0 Task 1–6 完成后即可跑通联调。
+
+---
+
+## 9. 变更记录
+
+| 日期 | 版本 | 说明 | 作者 |
+|------|------|------|------|
+| 2026-04-20 | v1 draft | 初稿 | @iannoying (via Claude) |

--- a/docs/plans/2026-04-20-m0-commercialization.md
+++ b/docs/plans/2026-04-20-m0-commercialization.md
@@ -1,0 +1,498 @@
+# M0 · 商业化基础设施 实施计划
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+> **Parent roadmap:** `docs/plans/2026-04-20-roadmap-vs-immersive-translate.md`
+> **Workflow:** 每个 Task 对应一个 GitHub Issue + 独立 feature branch + PR。
+
+**Goal:** 为所有付费功能铺设基础：entitlements 契约、feature flag、paywall 组件、后端联调规范。完成后任意业务功能只需 `if (!entitlement.canUse("x")) showUpgrade()` 即可接入商业化。
+
+**Architecture:**
+- 复用已就绪的 `better-auth` + `oRPC` + `PostHog` 三件套
+- 后端（独立 repo）新增 `billing.*` oRPC 路由，本 repo 消费它
+- Entitlements 双写：oRPC 实时查询 + Dexie 离线缓存（断网降级）
+- Feature flag 走 PostHog 标准 API（需打开 `advanced_disable_flags: false`）
+- Paywall UI 是复用组件，不是一次性弹窗
+
+**Tech Stack:** oRPC / Jotai / Dexie / better-auth / PostHog / shadcn
+
+**Out of scope（后端仓做）：** Stripe Webhook、订阅生命周期、配额扣减服务端逻辑、价格表配置。本 plan 只产出**契约 spec** 交给后端。
+
+---
+
+## 已有基础设施（不要重复造轮子）
+
+| 已有 | 文件 |
+|------|------|
+| better-auth React client | `src/utils/auth/auth-client.ts` — `authClient` |
+| oRPC client + tanstack-query utils | `src/utils/orpc/client.ts` — `orpcClient`, `orpc` |
+| Background fetch proxy | `src/utils/message.ts` — `sendMessage("backgroundFetch", ...)` |
+| PostHog analytics | `src/entrypoints/background/analytics.ts` |
+| Dexie app DB | `src/utils/db/dexie/app-db.ts` |
+| Jotai atoms | `src/utils/atoms/` |
+| shadcn Dialog/Button | `src/components/ui/` |
+
+---
+
+## Task 清单总览（8 个 Task / 8 个 Issue / 8 个 PR）
+
+| # | Task | 输出 | 预计 |
+|---|------|------|------|
+| 1 | Entitlements 契约类型定义 | `types/entitlements.ts` + zod schema | 0.5d |
+| 2 | Dexie `entitlements_cache` 表 + migration | 新表 + 读写 helper | 0.5d |
+| 3 | `useEntitlements` hook + 离线降级 | Jotai atom + hook | 1d |
+| 4 | PostHog Feature Flag 打开 + `useFeatureFlag` | 放开 flags + hook | 0.5d |
+| 5 | `<ProGate>` / `<UpgradeDialog>` 组件 | 可复用 paywall 基元 | 1d |
+| 6 | Options 页"账户与订阅"区块 | 登录态 + 订阅状态 + 升级入口 | 1d |
+| 7 | i18n 文案 | 中英 key | 0.5d |
+| 8 | 后端契约 spec 文档 | `docs/contracts/billing.md` 交给后端 | 1d |
+
+总计约 **6 个工作日**，但加上 PR review + 等后端联调，现实 2 周。
+
+---
+
+## Task 1: Entitlements 契约类型定义
+
+**Files:**
+- Create: `src/types/entitlements.ts`
+- Create: `src/types/__tests__/entitlements.test.ts`
+
+**Step 1: 写失败测试**
+
+```ts
+// src/types/__tests__/entitlements.test.ts
+import { describe, expect, it } from 'vitest'
+import { EntitlementsSchema, hasFeature, isPro } from '../entitlements'
+
+describe('EntitlementsSchema', () => {
+  it('validates a free user', () => {
+    const free = { tier: 'free', features: [], quota: {}, expiresAt: null }
+    expect(() => EntitlementsSchema.parse(free)).not.toThrow()
+  })
+
+  it('validates a pro user with expiry', () => {
+    const pro = {
+      tier: 'pro',
+      features: ['pdf_translate', 'input_translate_unlimited'],
+      quota: { ai_translate_monthly: { used: 1200, limit: 50000 } },
+      expiresAt: '2027-01-01T00:00:00.000Z',
+    }
+    expect(() => EntitlementsSchema.parse(pro)).not.toThrow()
+  })
+
+  it('rejects invalid tier', () => {
+    expect(() => EntitlementsSchema.parse({ tier: 'gold', features: [], quota: {}, expiresAt: null })).toThrow()
+  })
+})
+
+describe('hasFeature', () => {
+  it('returns true when feature is in list', () => {
+    const e = { tier: 'pro' as const, features: ['pdf_translate'], quota: {}, expiresAt: null }
+    expect(hasFeature(e, 'pdf_translate')).toBe(true)
+  })
+  it('returns false when feature missing', () => {
+    const e = { tier: 'free' as const, features: [], quota: {}, expiresAt: null }
+    expect(hasFeature(e, 'pdf_translate')).toBe(false)
+  })
+})
+
+describe('isPro', () => {
+  it('true for active pro', () => {
+    const e = { tier: 'pro' as const, features: [], quota: {}, expiresAt: new Date(Date.now() + 86400_000).toISOString() }
+    expect(isPro(e)).toBe(true)
+  })
+  it('false for expired pro', () => {
+    const e = { tier: 'pro' as const, features: [], quota: {}, expiresAt: new Date(Date.now() - 86400_000).toISOString() }
+    expect(isPro(e)).toBe(false)
+  })
+})
+```
+
+**Step 2: 验证失败**
+
+Run: `SKIP_FREE_API=true pnpm test src/types/__tests__/entitlements.test.ts`
+Expected: FAIL, "Cannot find module '../entitlements'"
+
+**Step 3: 最小实现**
+
+```ts
+// src/types/entitlements.ts
+import { z } from 'zod'
+
+export const FeatureKey = z.enum([
+  'pdf_translate',
+  'input_translate_unlimited',
+  'vocab_unlimited',
+  'vocab_cloud_sync',
+  'ai_translate_pool',
+  'subtitle_platforms_extended',
+  'enterprise_glossary_share',
+])
+export type FeatureKey = z.infer<typeof FeatureKey>
+
+export const QuotaBucketSchema = z.object({
+  used: z.number().int().nonnegative(),
+  limit: z.number().int().nonnegative(),
+})
+
+export const EntitlementsSchema = z.object({
+  tier: z.enum(['free', 'pro', 'enterprise']),
+  features: z.array(FeatureKey),
+  quota: z.record(z.string(), QuotaBucketSchema),
+  expiresAt: z.string().datetime().nullable(),
+})
+export type Entitlements = z.infer<typeof EntitlementsSchema>
+
+export function hasFeature(e: Entitlements, f: FeatureKey): boolean {
+  return e.features.includes(f)
+}
+
+export function isPro(e: Entitlements): boolean {
+  if (e.tier === 'free')
+    return false
+  if (e.expiresAt == null)
+    return e.tier === 'enterprise'
+  return Date.parse(e.expiresAt) > Date.now()
+}
+
+export const FREE_ENTITLEMENTS: Entitlements = {
+  tier: 'free',
+  features: [],
+  quota: {},
+  expiresAt: null,
+}
+```
+
+**Step 4: 测试通过**
+
+Run: `SKIP_FREE_API=true pnpm test src/types/__tests__/entitlements.test.ts`
+Expected: PASS (6 tests)
+
+**Step 5: Commit**
+
+```bash
+git add src/types/entitlements.ts src/types/__tests__/entitlements.test.ts
+git commit -m "feat(types): add entitlements schema and predicates"
+```
+
+---
+
+## Task 2: Dexie `entitlements_cache` 表 + migration
+
+**Files:**
+- Create: `src/utils/db/dexie/tables/entitlements-cache.ts`
+- Modify: `src/utils/db/dexie/app-db.ts`（注册新表，bump version）
+- Create: `src/utils/db/dexie/tables/__tests__/entitlements-cache.test.ts`
+
+**Step 1: 先读 `app-db.ts` 了解当前 version 和 table 声明模式**
+
+用 Read 工具查看 `src/utils/db/dexie/app-db.ts`；参考已有 `batch-request-record.ts` 表实现。
+
+**Step 2: 写失败测试**
+
+```ts
+// src/utils/db/dexie/tables/__tests__/entitlements-cache.test.ts
+import 'fake-indexeddb/auto'
+import { beforeEach, describe, expect, it } from 'vitest'
+import { appDb } from '@/utils/db/dexie/app-db'
+import { readCachedEntitlements, writeCachedEntitlements } from '../entitlements-cache'
+
+describe('entitlements-cache', () => {
+  beforeEach(async () => { await appDb.entitlementsCache.clear() })
+
+  it('writes and reads back entitlements by userId', async () => {
+    const e = { tier: 'pro' as const, features: ['pdf_translate' as const], quota: {}, expiresAt: '2099-01-01T00:00:00.000Z' }
+    await writeCachedEntitlements('user-1', e)
+    const got = await readCachedEntitlements('user-1')
+    expect(got?.value).toEqual(e)
+  })
+
+  it('returns null when userId absent', async () => {
+    expect(await readCachedEntitlements('missing')).toBeNull()
+  })
+})
+```
+
+（如果 `fake-indexeddb` 未装，改为 mock `appDb` 的 table；参考已有表测试。）
+
+**Step 3: 验证失败** → **Step 4: 实现** → **Step 5: 测试通过** → **Step 6: Commit**
+
+```bash
+git commit -m "feat(db): add entitlements_cache Dexie table"
+```
+
+---
+
+## Task 3: `useEntitlements` hook + 离线降级
+
+**Files:**
+- Create: `src/utils/atoms/entitlements.ts`
+- Create: `src/hooks/use-entitlements.ts`
+- Create: `src/hooks/__tests__/use-entitlements.test.tsx`
+
+**行为契约**：
+1. 优先读取 oRPC `billing.getEntitlements` 返回值 → 写入 atom + Dexie
+2. 网络失败或未登录 → 读 Dexie 缓存
+3. 两者都无 → 返回 `FREE_ENTITLEMENTS`
+4. session 变化（登录/登出）→ 自动重查
+
+**Step 1: 写失败测试（React Testing Library）**
+
+```tsx
+// src/hooks/__tests__/use-entitlements.test.tsx
+import { renderHook, waitFor } from '@testing-library/react'
+import { describe, expect, it, vi } from 'vitest'
+import { useEntitlements } from '../use-entitlements'
+
+vi.mock('@/utils/orpc/client', () => ({
+  orpcClient: { billing: { getEntitlements: vi.fn() } },
+}))
+
+describe('useEntitlements', () => {
+  it('returns FREE when user not signed in', async () => {
+    const { result } = renderHook(() => useEntitlements({ userId: null }))
+    await waitFor(() => expect(result.current.data?.tier).toBe('free'))
+  })
+
+  it('returns pro entitlements from orpc on success', async () => {
+    const { orpcClient } = await import('@/utils/orpc/client')
+    ;(orpcClient.billing.getEntitlements as any).mockResolvedValue({
+      tier: 'pro', features: ['pdf_translate'], quota: {}, expiresAt: '2099-01-01T00:00:00.000Z',
+    })
+    const { result } = renderHook(() => useEntitlements({ userId: 'user-1' }))
+    await waitFor(() => expect(result.current.data?.tier).toBe('pro'))
+  })
+
+  it('falls back to Dexie cache on network error', async () => {
+    const { orpcClient } = await import('@/utils/orpc/client')
+    ;(orpcClient.billing.getEntitlements as any).mockRejectedValue(new Error('offline'))
+    // seed cache first (via the module under test or direct writeCachedEntitlements)
+    // ...
+    const { result } = renderHook(() => useEntitlements({ userId: 'user-1' }))
+    await waitFor(() => expect(result.current.data?.tier).toBe('pro'))
+  })
+})
+```
+
+**Step 2-5:** 失败验证 → 实现（Jotai atom + tanstack-query `useQuery` 包装 orpc 调用 + Dexie fallback）→ 通过 → Commit
+
+```bash
+git commit -m "feat(hooks): add useEntitlements with offline fallback"
+```
+
+---
+
+## Task 4: PostHog Feature Flag 打开 + `useFeatureFlag`
+
+**当前状态**：`analytics.ts` 第 169 行 `advanced_disable_flags: true` 明确关闭了 flags。
+
+**Files:**
+- Modify: `src/entrypoints/background/analytics.ts:169`（改为 `false`）
+- Create: `src/utils/message.ts` 新增 `getFeatureFlag` 消息类型（content/popup 需通过 background 查询）
+- Create: `src/hooks/use-feature-flag.ts`
+- Create: `src/hooks/__tests__/use-feature-flag.test.tsx`
+
+**风险**：打开 flags 会让 PostHog SDK 额外拉取 flag 定义，影响 background 启动时间。`createBackgroundAnalytics` 里测试好 `advanced_disable_flags: false` 不破坏既有 analytics 测试。
+
+**Step 1-5:** 标准 TDD 循环
+
+**Commit:**
+```bash
+git commit -m "feat(analytics): enable PostHog feature flags and expose useFeatureFlag"
+```
+
+---
+
+## Task 5: `<ProGate>` / `<UpgradeDialog>` 组件
+
+**Files:**
+- Create: `src/components/billing/pro-gate.tsx`
+- Create: `src/components/billing/upgrade-dialog.tsx`
+- Create: `src/components/billing/__tests__/pro-gate.test.tsx`
+
+**API 设计**：
+
+```tsx
+<ProGate feature="pdf_translate" fallback={<UpgradeDialog trigger="pdf" />}>
+  <PdfTranslateButton />
+</ProGate>
+```
+
+或者命令式：
+
+```ts
+const { guard } = useProGuard()
+function handleClick() {
+  if (!guard('pdf_translate', { trigger: 'pdf' }))
+    return
+  doPdfTranslate()
+}
+```
+
+**Step 1: 写失败测试**
+
+```tsx
+// src/components/billing/__tests__/pro-gate.test.tsx
+import { render, screen } from '@testing-library/react'
+import { describe, expect, it, vi } from 'vitest'
+import { ProGate } from '../pro-gate'
+
+vi.mock('@/hooks/use-entitlements', () => ({
+  useEntitlements: vi.fn(),
+}))
+
+describe('<ProGate>', () => {
+  it('renders children when feature granted', async () => {
+    const { useEntitlements } = await import('@/hooks/use-entitlements')
+    ;(useEntitlements as any).mockReturnValue({ data: { tier: 'pro', features: ['pdf_translate'], quota: {}, expiresAt: null } })
+    render(<ProGate feature="pdf_translate" fallback={<span>upgrade</span>}><span>content</span></ProGate>)
+    expect(screen.getByText('content')).toBeInTheDocument()
+  })
+
+  it('renders fallback when feature missing', async () => {
+    const { useEntitlements } = await import('@/hooks/use-entitlements')
+    ;(useEntitlements as any).mockReturnValue({ data: { tier: 'free', features: [], quota: {}, expiresAt: null } })
+    render(<ProGate feature="pdf_translate" fallback={<span>upgrade</span>}><span>content</span></ProGate>)
+    expect(screen.getByText('upgrade')).toBeInTheDocument()
+  })
+})
+```
+
+**Step 2-5:** 实现 + Commit
+
+```bash
+git commit -m "feat(billing): add ProGate and UpgradeDialog components"
+```
+
+---
+
+## Task 6: Options 页"账户与订阅"区块
+
+**Files:**
+- Create: `src/entrypoints/options/routes/account.tsx`（复用 existing options routing）
+- Modify: options 侧边栏导航加入"账户"入口
+
+**UI 内容**：
+- 未登录：展示"登录后享受云同步 / Pro 额度"按钮 → 跳转 `${WEBSITE_URL}/login`
+- 已登录 Free：展示 `tier: Free` + "升级到 Pro" 按钮 → 跳转 `${WEBSITE_URL}/pricing`
+- Pro：tier + expiresAt + 配额进度条 + "管理订阅"（跳 Stripe Customer Portal）
+
+本 Task **不做 Stripe 集成**，只跳转到 Web 站点（Web 站点的 pricing/portal 由后端团队维护）。
+
+**Commit:**
+```bash
+git commit -m "feat(options): add account and subscription section"
+```
+
+---
+
+## Task 7: i18n 文案
+
+**Files:**
+- Modify: `src/locales/en.json` / `src/locales/zh-CN.json`（和其他已有语种）
+
+新增 key：
+```
+billing.tier.free / tier.pro / tier.enterprise
+billing.upgrade.cta / upgrade.title / upgrade.description
+billing.quota.remaining / quota.exhausted
+billing.expiry.active / expiry.expired
+billing.account.signIn / signOut / managePlan
+```
+
+所有 `<ProGate fallback>` 和 `<UpgradeDialog>` 使用 `@wxt-dev/i18n` 的 `t()`。
+
+**Commit:**
+```bash
+git commit -m "feat(i18n): add billing and paywall copy"
+```
+
+---
+
+## Task 8: 后端契约 spec
+
+**Files:**
+- Create: `docs/contracts/billing.md`
+
+**不是代码**，是交付给后端 repo（`read-frog-monorepo` / `@read-frog/api-contract`）的规范。内容：
+
+```md
+# billing 契约 (v1)
+
+## Procedures
+
+### billing.getEntitlements
+- Auth: required (better-auth session)
+- Input: `{}`
+- Output: `Entitlements`（schema 见 extension repo `src/types/entitlements.ts`）
+- Caching: `Cache-Control: private, max-age=30`
+- Errors: `UNAUTHENTICATED` → 401
+
+### billing.consumeQuota
+- Auth: required
+- Input: `{ bucket: string, amount: number }`
+- Output: `{ remaining: number, reset_at: string }`
+- Errors: `QUOTA_EXCEEDED` → 402
+
+### billing.createCheckoutSession
+- Auth: required
+- Input: `{ plan: 'pro_monthly' | 'pro_yearly', successUrl: string, cancelUrl: string }`
+- Output: `{ url: string }`（Stripe Checkout URL）
+
+### billing.createPortalSession
+- Auth: required
+- Input: `{}`
+- Output: `{ url: string }`
+
+## Stripe Webhook（后端内部）
+- `customer.subscription.created` / `.updated` / `.deleted` → 更新 `user_entitlements` 表
+- `invoice.payment_failed` → 保留 Pro 7 天宽限期
+- 所有 webhook 处理必须幂等（dedup by `event.id`）
+```
+
+**Commit:**
+```bash
+git add docs/contracts/billing.md
+git commit -m "docs(contracts): spec billing oRPC procedures for backend"
+```
+
+---
+
+## M0 验收标准
+
+- [ ] 8 个 PR 全部 merge 到 `main`
+- [ ] `SKIP_FREE_API=true pnpm test` 绿，新增测试 ≥ 15
+- [ ] `pnpm type-check && pnpm lint` 无错
+- [ ] 本地 `pnpm dev`：
+  - Options 页"账户"能看到登录态
+  - 登录 Free 账号能看到"升级"入口
+  - 任意 Pro 功能（暂无真实功能时用 demo 页面）能正确 gate
+- [ ] `docs/contracts/billing.md` 已提交给后端，后端完成 `billing.*` 实装
+- [ ] Changeset 记录：`feat: commercialization infrastructure (M0)`
+
+---
+
+## 依赖图
+
+```
+Task 1 (types) ────────┐
+                       ├──▶ Task 3 (hook)
+Task 2 (db table) ─────┘        │
+                                ├──▶ Task 5 (ProGate)
+Task 4 (flags) ─────────────────┤        │
+                                │        ├──▶ Task 6 (Options UI)
+                                └────────┘
+Task 7 (i18n) ────── 并行
+Task 8 (contract doc) ── 立即开写，阻塞后端
+```
+
+**串行做或 stack PR**：Task 3 依赖 1+2，Task 5 依赖 3，Task 6 依赖 5。
+
+**可并行**：Task 4、7、8 独立，任何时候都能开。
+
+**Task 8 优先**：越早交付后端契约，后端越早开工，越能压缩 M0 实际时长。
+
+---
+
+## 下一步
+
+Issues 草稿见同目录 `2026-04-20-m0-issues.md`。检查后可直接 `gh issue create` 批量建。

--- a/docs/plans/2026-04-20-m0-issues.md
+++ b/docs/plans/2026-04-20-m0-issues.md
@@ -1,0 +1,364 @@
+# M0 Issues 草稿
+
+> 对应计划：`docs/plans/2026-04-20-m0-commercialization.md`
+> 审核后可用 `gh issue create` 批量建。建议先建 Epic，再用 `--body` 引用到 Epic。
+
+## 通用标签
+
+建议先建好这些 label（`gh label create`）：
+
+```bash
+gh label create "milestone:m0"     --color "0E8A16" --description "M0 商业化基础设施"
+gh label create "type:epic"        --color "5319E7" --description "Epic / tracking issue"
+gh label create "type:feature"     --color "1D76DB"
+gh label create "type:contract"    --color "C2E0C6" --description "后端/前端契约"
+gh label create "area:billing"     --color "FBCA04"
+gh label create "area:db"          --color "D4C5F9"
+gh label create "area:analytics"   --color "C5DEF5"
+gh label create "area:ui"          --color "BFD4F2"
+gh label create "area:i18n"        --color "E99695"
+```
+
+---
+
+## Epic: M0 商业化基础设施
+
+**Title:** `Epic: M0 · Commercialization infrastructure (entitlements, feature flags, paywall)`
+**Labels:** `milestone:m0,type:epic,area:billing`
+**Body:**
+
+```md
+## Goal
+Lay the groundwork for the Free / Pro / Enterprise business model. After this epic, any feature can be gated behind `<ProGate feature="..." />` without touching billing wiring.
+
+## Plan
+See `docs/plans/2026-04-20-m0-commercialization.md`.
+
+## Sub-issues
+- [ ] #<num> Entitlements schema + predicates
+- [ ] #<num> Dexie entitlements_cache table
+- [ ] #<num> useEntitlements hook with offline fallback
+- [ ] #<num> Enable PostHog feature flags + useFeatureFlag
+- [ ] #<num> ProGate + UpgradeDialog components
+- [ ] #<num> Options page "Account & Subscription" section
+- [ ] #<num> i18n copy for billing/paywall
+- [ ] #<num> Backend contract spec for billing.* procedures
+
+## Out of scope (backend repo)
+- Stripe webhook handling
+- Subscription lifecycle management
+- Pricing table config
+
+## Definition of done
+- All sub-issues merged to `main`
+- `pnpm test && pnpm type-check && pnpm lint` green
+- Backend `billing.*` procedures implemented per contract spec
+- Changeset recorded: "feat: commercialization infrastructure (M0)"
+```
+
+---
+
+## Issue 1: Entitlements schema
+
+**Title:** `feat(types): add entitlements schema and predicates`
+**Labels:** `milestone:m0,type:feature,area:billing`
+**Body:**
+
+```md
+## Context
+First brick of M0. Define the shape of user entitlements consumed by extension and produced by backend.
+
+## Deliverable
+- `src/types/entitlements.ts` — zod `EntitlementsSchema`, `FeatureKey` enum, `hasFeature()`, `isPro()`, `FREE_ENTITLEMENTS` constant
+- `src/types/__tests__/entitlements.test.ts` — ≥6 tests covering valid/invalid parse, feature check, expiry
+
+## Plan reference
+`docs/plans/2026-04-20-m0-commercialization.md` · Task 1
+
+## Branch
+`feat/m0-entitlements-schema`
+
+## Acceptance
+- [ ] Schema validates free/pro/enterprise shapes
+- [ ] `isPro` handles expired timestamps correctly
+- [ ] No new runtime deps
+```
+
+---
+
+## Issue 2: Dexie table
+
+**Title:** `feat(db): add entitlements_cache Dexie table`
+**Labels:** `milestone:m0,type:feature,area:db`
+**Body:**
+
+```md
+## Context
+Cache entitlements locally for offline/session-resume. Falls back when backend unreachable.
+
+## Deliverable
+- `src/utils/db/dexie/tables/entitlements-cache.ts` — `writeCachedEntitlements`, `readCachedEntitlements`
+- Register in `src/utils/db/dexie/app-db.ts`, bump db version (follow existing migration convention)
+- Tests
+
+## Plan reference
+`docs/plans/2026-04-20-m0-commercialization.md` · Task 2
+
+## Branch
+`feat/m0-entitlements-cache`
+
+## Depends on
+#<Issue 1>
+
+## Acceptance
+- [ ] Existing Dexie migration tests still pass
+- [ ] Round-trip read/write tested
+```
+
+---
+
+## Issue 3: useEntitlements hook
+
+**Title:** `feat(hooks): add useEntitlements with offline fallback`
+**Labels:** `milestone:m0,type:feature,area:billing`
+**Body:**
+
+```md
+## Context
+React hook consuming oRPC `billing.getEntitlements` with Dexie cache fallback and Jotai atom for cross-component sync.
+
+## Behavior
+1. On mount (and on session change), call `orpcClient.billing.getEntitlements()`
+2. On success → write to Jotai atom + Dexie
+3. On error → read Dexie cache
+4. If both fail → `FREE_ENTITLEMENTS`
+
+## Deliverable
+- `src/utils/atoms/entitlements.ts`
+- `src/hooks/use-entitlements.ts`
+- Tests with mocked orpcClient
+
+## Plan reference
+`docs/plans/2026-04-20-m0-commercialization.md` · Task 3
+
+## Branch
+`feat/m0-use-entitlements`
+
+## Depends on
+#<Issue 1>, #<Issue 2>
+
+## Acceptance
+- [ ] Returns Free for anonymous user
+- [ ] Returns Pro from backend on happy path
+- [ ] Falls back to Dexie on network error
+```
+
+---
+
+## Issue 4: PostHog feature flags
+
+**Title:** `feat(analytics): enable PostHog feature flags and expose useFeatureFlag`
+**Labels:** `milestone:m0,type:feature,area:analytics`
+**Body:**
+
+```md
+## Context
+`src/entrypoints/background/analytics.ts:169` currently sets `advanced_disable_flags: true`, which blocks flag delivery. Flip it, and add a hook for content/popup/options to consume flags through a background message.
+
+## Deliverable
+- Flip `advanced_disable_flags` → `false`
+- `getFeatureFlag` message type in `src/utils/message.ts`
+- `src/hooks/use-feature-flag.ts`
+- Ensure existing analytics tests still pass
+
+## Plan reference
+`docs/plans/2026-04-20-m0-commercialization.md` · Task 4
+
+## Branch
+`feat/m0-feature-flags`
+
+## Risk
+PostHog init may add ~50ms to background startup; benchmark before/after.
+
+## Acceptance
+- [ ] Flag value reachable from a content script
+- [ ] Falls back to `defaultValue` when PostHog not configured
+- [ ] No regression in `analytics.test.ts`
+```
+
+---
+
+## Issue 5: ProGate component
+
+**Title:** `feat(billing): add ProGate and UpgradeDialog components`
+**Labels:** `milestone:m0,type:feature,area:ui,area:billing`
+**Body:**
+
+```md
+## Context
+Reusable paywall primitives. Any feature gates itself with `<ProGate feature="..." fallback={<UpgradeDialog/>}>`.
+
+## Deliverable
+- `src/components/billing/pro-gate.tsx`
+- `src/components/billing/upgrade-dialog.tsx`
+- `useProGuard()` imperative variant
+- Tests
+
+## Plan reference
+`docs/plans/2026-04-20-m0-commercialization.md` · Task 5
+
+## Branch
+`feat/m0-pro-gate`
+
+## Depends on
+#<Issue 3>, #<Issue 7 (i18n, can merge after)>
+
+## Acceptance
+- [ ] Children render when entitlement granted
+- [ ] Fallback renders otherwise
+- [ ] UpgradeDialog CTA links to `${WEBSITE_URL}/pricing`
+```
+
+---
+
+## Issue 6: Options page Account section
+
+**Title:** `feat(options): add account and subscription section`
+**Labels:** `milestone:m0,type:feature,area:ui,area:billing`
+**Body:**
+
+```md
+## Context
+User-facing entry to sign in / check plan / manage subscription. Pure UI on top of `useEntitlements` — no new billing logic.
+
+## Deliverable
+- New options route `account.tsx`
+- Sidebar nav entry
+- States: anonymous / free / pro / enterprise
+
+## Plan reference
+`docs/plans/2026-04-20-m0-commercialization.md` · Task 6
+
+## Branch
+`feat/m0-options-account`
+
+## Depends on
+#<Issue 3>, #<Issue 5>, #<Issue 7>
+
+## Acceptance
+- [ ] Shows tier + expiresAt for Pro
+- [ ] "Manage Plan" opens `${WEBSITE_URL}/account/billing` in new tab
+- [ ] "Sign in" kicks off better-auth flow
+```
+
+---
+
+## Issue 7: i18n copy
+
+**Title:** `feat(i18n): add billing and paywall copy`
+**Labels:** `milestone:m0,type:feature,area:i18n`
+**Body:**
+
+```md
+## Context
+Add all billing-related copy keys across supported locales. Keeps Task 5 & 6 unblocked.
+
+## Deliverable
+Keys under `billing.*` namespace in `src/locales/*.json`:
+- `billing.tier.{free,pro,enterprise}`
+- `billing.upgrade.{cta,title,description}`
+- `billing.quota.{remaining,exhausted}`
+- `billing.expiry.{active,expired}`
+- `billing.account.{signIn,signOut,managePlan}`
+
+## Plan reference
+`docs/plans/2026-04-20-m0-commercialization.md` · Task 7
+
+## Branch
+`feat/m0-billing-i18n`
+
+## Acceptance
+- [ ] All supported locales covered (list per `src/locales/`)
+- [ ] No missing-key warnings on build
+```
+
+---
+
+## Issue 8: Backend contract spec
+
+**Title:** `docs(contracts): spec billing.* oRPC procedures for backend`
+**Labels:** `milestone:m0,type:contract,area:billing`
+**Body:**
+
+```md
+## Context
+Document the oRPC contract that backend (`@read-frog/api-contract`) must implement. Unblocks backend work in parallel with extension tasks.
+
+## Deliverable
+`docs/contracts/billing.md` covering:
+- `billing.getEntitlements`
+- `billing.consumeQuota`
+- `billing.createCheckoutSession`
+- `billing.createPortalSession`
+- Stripe webhook expectations
+
+## Plan reference
+`docs/plans/2026-04-20-m0-commercialization.md` · Task 8
+
+## Branch
+`docs/m0-billing-contract`
+
+## Acceptance
+- [ ] Each procedure: input / output / auth / errors documented
+- [ ] Cross-linked from extension `src/types/entitlements.ts`
+- [ ] Shared with backend team (paste link in `read-frog-monorepo` issue tracker)
+```
+
+---
+
+## 批量建 Issue 脚本示例
+
+审核后可用如下 bash 脚本一次性建完。`--body-file` 读取每个 issue 的 body（预先拆到独立文件），或者直接 heredoc：
+
+```bash
+# 1. 建 Epic，记录 URL
+EPIC_URL=$(gh issue create --title "Epic: M0 · Commercialization infrastructure" \
+  --label "milestone:m0,type:epic,area:billing" \
+  --body-file docs/plans/m0-epic-body.md)
+EPIC_NUM=$(echo "$EPIC_URL" | grep -oE '[0-9]+$')
+
+# 2. 逐个建子 issue，body 里用 `Part of #$EPIC_NUM`
+gh issue create --title "feat(types): add entitlements schema and predicates" \
+  --label "milestone:m0,type:feature,area:billing" \
+  --body "Part of #$EPIC_NUM. See docs/plans/2026-04-20-m0-commercialization.md · Task 1"
+
+# ...依次建剩余 7 个
+
+# 3. 回头编辑 Epic，把子 issue 编号填进 checklist
+gh issue edit $EPIC_NUM --body "$(cat updated-epic-body.md)"
+```
+
+---
+
+## 执行节奏
+
+**Week 1**
+- Day 1: Epic + Issue 1,2,4,7,8 建好；**Task 8 优先动手**（后端最早启动）
+- Day 2–3: Task 1 → 2 → 4 并行 PR
+- Day 4: Task 7 PR（小、快）
+- Day 5: Task 3 PR
+
+**Week 2**
+- Day 6: Task 5 PR
+- Day 7: Task 6 PR
+- Day 8–10: 后端联调 + bug fix + Changeset
+
+每个 PR 执行流：
+
+```bash
+/fix-github-issue <num>   # 拉分支 + 读 plan
+# ...TDD 开发...
+/commit                   # 按 commitlint 规范提交
+/prepare-pr <num>         # 跑 test/lint/type-check
+/create-pr <num>          # 开 PR，body 自动关联 issue
+```

--- a/docs/plans/2026-04-20-roadmap-vs-immersive-translate.md
+++ b/docs/plans/2026-04-20-roadmap-vs-immersive-translate.md
@@ -1,0 +1,645 @@
+# Read Frog 对标沉浸式翻译 中长期路线图与 M1 实施计划
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+> **Scope note:** 本文件既是 **路线图（M0–M6）** 也是 **M1 的可执行 TDD 计划**。M2+ 的每个里程碑在开工前需重新走一遍 `superpowers:brainstorming` + `superpowers:writing-plans`，细化成新的 plan 文件。
+
+**Goal:** 把 Read Frog 发展为"免费基础翻译 + 付费增强"的商业化浏览器翻译插件，在关键体验上追平沉浸式翻译，同时用 AI 语言学习差异化。
+
+**Architecture:** 以现有 WXT + React 19 + Vercel AI SDK + Jotai + Dexie 技术栈为基座，按"核心触达 → 文档扩展 → 平台适配 → 学习闭环 → 商业化"五阶段渐进式扩展；所有外部翻译引擎通过统一 `TranslationProvider` 接口插拔；付费闭环建立在 better-auth + 现有 oRPC 后端上。
+
+**Tech Stack:** WXT 0.20 / React 19 / Vercel AI SDK v6 / Jotai / Dexie / oRPC + better-auth / Tailwind v4 + shadcn / PostHog
+
+---
+
+## 战略定位
+
+| 维度 | 沉浸式翻译 | Read Frog 现状 | Read Frog 目标 |
+|------|-----------|---------------|---------------|
+| 触达面 | 网页/PDF/EPUB/字幕/输入框/图片 | 网页 + YouTube 字幕 | 追平 |
+| 引擎 | DeepL/有道/腾讯/Google/AI 全家桶 | 3 免费 + 20+ AI | 补传统引擎 |
+| 学习闭环 | 基础生词本 | 精读 + TTS（无闭环） | **差异化护城河** |
+| 商业化 | Pro 订阅 + 免费额度池 | BYO-Key 开源 | 三层：免费 / Pro / Enterprise |
+
+**护城河**：沉浸式翻译 = "更快更全的翻译工具"；Read Frog = "AI 语言学习伴侣"（精读 + 生词本 + Anki + 自适应解释）。**不能在引擎数量上内卷**，要在学习闭环上做深。
+
+---
+
+## 里程碑路线图
+
+每个 **M** 约 2–4 周 / 1 人。优先级按"用户留存 × 付费意愿 / 工程复杂度"排序。
+
+### M0 · 商业化基础设施（2 周，先行依赖）
+为所有付费功能铺路。
+- 打通 better-auth 登录态在 extension 三端（popup/options/content）的同步
+- 后端 `@read-frog/api-contract` 新增 `billing.*` 路由：`getEntitlements`、`consumeQuota`、Stripe webhook
+- 本地 `EntitlementsContext` atom + Dexie 缓存（离线降级）
+- Feature flag 机制（PostHog 已接入，只需包一层 `useFeatureFlag`）
+
+**交付验证**：在任意功能入口加 `if (!entitlement.pro) showUpgrade()` 能正常拦截。
+
+### M1 · 官方免费翻译引擎矩阵（2 周）⭐ 本文档详细拆解
+沉浸式的免费用户全靠 Google/Bing Web 接口。Read Frog 当前已有 `google.ts`/`microsoft.ts`/`deeplx.ts`，但**只有 1–2 种实现**，稳定性不足。
+
+目标：扩展 `TranslationProvider` 到 **Google Web / Microsoft Edge Auth / Bing Web / Yandex Web / LibreTranslate** 五家免费；增加健康探测 + 自动回退 + 限频熔断。
+
+这是免费用户的生命线，也是承载千万级调用的基础设施。详见下文 **M1 任务拆解**。
+
+### M2 · 输入框增强翻译（1.5 周）
+沉浸式招牌功能。触发词如 `//en ` 自动把中文翻译为英文回填。
+- 通用监听器：`contenteditable`、`<textarea>`、`<input>`
+- 配置表：按域名 allowlist + 触发 token
+- 冲突处理：飞书/Slack/WeChat Web 等富文本编辑器需单独适配
+- **定价**：免费版每日 50 次；Pro 无限
+
+### M3 · PDF 双语翻译（3 周）
+基于 pdf.js viewer 注入覆盖层；不解析 PDF 源文件，而是在浏览器渲染后对 text layer 分段翻译并悬浮叠加。
+- 复用现有段落批量翻译 pipeline
+- 支持下载"带翻译标注的 PDF"（Pro 专享）
+- **定价**：免费版水印 + 50 页/天；Pro 无水印无限制
+
+### M4 · 字幕/视频平台扩展（2 周）
+从 YouTube 扩展到 Netflix / Bilibili / X(Twitter) / TED / Udemy / Coursera。
+- 抽象 `SubtitleAdapter` 接口，YouTube 改造成首个实现
+- 每个平台独立 content script + manifest host permission
+- 社区贡献友好：`src/entrypoints/subtitles.content/adapters/` 插件式目录
+
+### M5 · 生词本 + Anki 闭环（3 周）⭐ 差异化核心
+- Dexie schema：`words` 表（word / context / translation / mastery / next_review_at）
+- 划词工具栏新增"加入生词本"按钮（复用现有 selection toolbar）
+- SM-2 遗忘曲线调度，popup 新增"今日复习"页
+- 导出：Anki `.apkg` / CSV / Obsidian Markdown
+- **定价**：免费版 100 词；Pro 无限 + 云同步
+
+### M6 · 术语表 + 风格库（1 周）
+- 术语表：`{src, dst, context?}` 绑定到自定义 prompt，注入 `[GLOSSARY]` token
+- 显示样式模板库：下划线/模糊/遮罩/行内替换 20+ preset
+
+### 后续（非优先）
+- EPUB / SRT / DOCX 文件上传翻译（M7）
+- 图片 OCR 翻译（M8，需 Vision 模型）
+- 会议实时语音翻译（M9，复杂度高）
+- WebDAV / Supabase 云同步（M10，与生词本耦合）
+
+---
+
+## 商业化分层（三档）
+
+| 档位 | 功能 | 定价 |
+|------|------|------|
+| Free | 全部官方免费引擎 / 基础网页翻译 / 50 次·日输入框 / 50 页·日 PDF / 100 词生词本 | ¥0 |
+| Pro | 无限引擎调用 / 去水印 PDF 下载 / 无限输入框 / 无限生词本 + 云同步 / 所有付费 AI 引擎额度池 | ¥28/月 或 ¥198/年 |
+| Enterprise | 团队术语表共享 / SSO / 审计日志 / SLA | 按座席 |
+
+**免费额度池**（Pro 专享 AI 调用）：后端走我们自己的 key，限流 + 计费，类似沉浸式的 "BabelDOC 额度"。用 M0 的 entitlements 接口扣减。
+
+---
+
+# M1 任务拆解（可执行 TDD 计划）
+
+**M1 目标**：新增 3 个免费翻译 provider（Bing Web / Yandex Web / LibreTranslate），抽出统一 `FreeProviderHealth` 熔断层，失败自动回退。
+
+**前置阅读**：
+- `src/utils/host/translate/api/index.ts` — 现有免费 provider 调度器
+- `src/utils/host/translate/api/google.ts` / `microsoft.ts` — 参考实现
+- `src/utils/host/translate/api/__tests__/` — 测试惯例
+- `AGENTS.md` — Testing Notes 段落（`SKIP_FREE_API=true`）
+
+**通用约定**：
+- 所有新 provider 放在 `src/utils/host/translate/api/`
+- 测试放在 `src/utils/host/translate/api/__tests__/`，仿照现有 `free-api.test.ts` 的 describe 分组
+- 每个 provider 必须导出 `translate(input: TranslateInput): Promise<TranslateOutput>` 签名和 `kind: "bing" | "yandex" | "libre"` 常量
+- 网络请求走 `src/utils/http.ts` 封装（已有）
+
+---
+
+## Task 1: 抽取 `FreeProviderHealth` 熔断层
+
+**Files:**
+- Create: `src/utils/host/translate/api/health.ts`
+- Create: `src/utils/host/translate/api/__tests__/health.test.ts`
+
+**Step 1: 写失败测试**
+
+```ts
+// src/utils/host/translate/api/__tests__/health.test.ts
+import { describe, expect, it, vi } from 'vitest'
+import { createHealthTracker } from '../health'
+
+describe('FreeProviderHealth', () => {
+  it('blocks provider after 3 consecutive failures within 60s', () => {
+    const now = vi.fn(() => 1000)
+    const h = createHealthTracker({ now, windowMs: 60_000, threshold: 3 })
+    h.recordFailure('google')
+    h.recordFailure('google')
+    expect(h.isHealthy('google')).toBe(true)
+    h.recordFailure('google')
+    expect(h.isHealthy('google')).toBe(false)
+  })
+
+  it('recovers after cooldown', () => {
+    let t = 1000
+    const h = createHealthTracker({ now: () => t, windowMs: 60_000, threshold: 3, cooldownMs: 30_000 })
+    h.recordFailure('bing'); h.recordFailure('bing'); h.recordFailure('bing')
+    expect(h.isHealthy('bing')).toBe(false)
+    t = 1000 + 31_000
+    expect(h.isHealthy('bing')).toBe(true)
+  })
+
+  it('recordSuccess resets counter', () => {
+    const h = createHealthTracker({ now: () => 1000, windowMs: 60_000, threshold: 3 })
+    h.recordFailure('yandex'); h.recordFailure('yandex')
+    h.recordSuccess('yandex')
+    h.recordFailure('yandex'); h.recordFailure('yandex')
+    expect(h.isHealthy('yandex')).toBe(true)
+  })
+})
+```
+
+**Step 2: 验证失败**
+
+Run: `SKIP_FREE_API=true pnpm test src/utils/host/translate/api/__tests__/health.test.ts`
+Expected: FAIL, "Cannot find module '../health'"
+
+**Step 3: 最小实现**
+
+```ts
+// src/utils/host/translate/api/health.ts
+export type ProviderKind = 'google' | 'microsoft' | 'bing' | 'yandex' | 'libre' | 'deeplx'
+
+export interface HealthOptions {
+  now?: () => number
+  windowMs?: number
+  threshold?: number
+  cooldownMs?: number
+}
+
+export function createHealthTracker(opts: HealthOptions = {}) {
+  const now = opts.now ?? (() => Date.now())
+  const windowMs = opts.windowMs ?? 60_000
+  const threshold = opts.threshold ?? 3
+  const cooldownMs = opts.cooldownMs ?? 30_000
+  const failures = new Map<string, number[]>()
+  const blockedUntil = new Map<string, number>()
+
+  return {
+    recordFailure(k: ProviderKind) {
+      const t = now()
+      const arr = (failures.get(k) ?? []).filter(ts => t - ts < windowMs)
+      arr.push(t)
+      failures.set(k, arr)
+      if (arr.length >= threshold)
+        blockedUntil.set(k, t + cooldownMs)
+    },
+    recordSuccess(k: ProviderKind) {
+      failures.delete(k)
+      blockedUntil.delete(k)
+    },
+    isHealthy(k: ProviderKind) {
+      const until = blockedUntil.get(k)
+      if (until == null)
+        return true
+      if (now() >= until) {
+        blockedUntil.delete(k)
+        return true
+      }
+      return false
+    },
+  }
+}
+```
+
+**Step 4: 测试通过**
+
+Run: `SKIP_FREE_API=true pnpm test src/utils/host/translate/api/__tests__/health.test.ts`
+Expected: PASS (3 tests)
+
+**Step 5: Commit**
+
+```bash
+git add src/utils/host/translate/api/health.ts src/utils/host/translate/api/__tests__/health.test.ts
+git commit -m "feat(translate): add FreeProviderHealth circuit breaker"
+```
+
+---
+
+## Task 2: Bing Web 翻译 provider
+
+Bing 免费翻译通过 `https://www.bing.com/ttranslatev3` 接口，需要先抓 IG/IID token。
+
+**Files:**
+- Create: `src/utils/host/translate/api/bing.ts`
+- Create: `src/utils/host/translate/api/__tests__/bing.test.ts`
+
+**Step 1: 写失败测试（mock fetch）**
+
+```ts
+// src/utils/host/translate/api/__tests__/bing.test.ts
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { translateBing } from '../bing'
+
+describe('translateBing', () => {
+  beforeEach(() => vi.restoreAllMocks())
+
+  it('returns translated text on happy path', async () => {
+    const html = '<html>IG:"ABC"; _G.IID="translator.5024"</html>'
+    vi.stubGlobal('fetch', vi.fn()
+      .mockResolvedValueOnce({ ok: true, text: async () => html })
+      .mockResolvedValueOnce({ ok: true, json: async () => [{ translations: [{ text: '你好' }] }] }))
+    await expect(translateBing({ text: 'hello', from: 'en', to: 'zh-CN' }))
+      .resolves.toEqual({ text: '你好' })
+  })
+
+  it('throws on missing IG token', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValueOnce({ ok: true, text: async () => '<html>no tokens</html>' }))
+    await expect(translateBing({ text: 'hi', from: 'en', to: 'zh-CN' }))
+      .rejects.toThrow(/IG/i)
+  })
+})
+```
+
+**Step 2: 验证失败**
+
+Run: `SKIP_FREE_API=true pnpm test src/utils/host/translate/api/__tests__/bing.test.ts`
+Expected: FAIL
+
+**Step 3: 最小实现**
+
+```ts
+// src/utils/host/translate/api/bing.ts
+export interface BingInput { text: string, from: string, to: string }
+export interface BingOutput { text: string }
+
+let tokenCache: { ig: string, iid: string, key: string, token: string, fetchedAt: number } | null = null
+const TOKEN_TTL = 30 * 60_000
+
+async function fetchToken() {
+  if (tokenCache && Date.now() - tokenCache.fetchedAt < TOKEN_TTL)
+    return tokenCache
+  const res = await fetch('https://www.bing.com/translator')
+  const html = await res.text()
+  const ig = html.match(/IG:"([^"]+)"/)?.[1]
+  const iid = html.match(/_G\.IID="([^"]+)"/)?.[1]
+  const params = html.match(/params_AbusePreventionHelper\s*=\s*\[(\d+),"([^"]+)"/)
+  if (!ig || !iid || !params)
+    throw new Error('Bing translator IG/IID/key not found')
+  tokenCache = { ig, iid, key: params[1], token: params[2], fetchedAt: Date.now() }
+  return tokenCache
+}
+
+export async function translateBing(input: BingInput): Promise<BingOutput> {
+  const t = await fetchToken()
+  const url = `https://www.bing.com/ttranslatev3?isVertical=1&IG=${t.ig}&IID=${t.iid}`
+  const body = new URLSearchParams({ fromLang: input.from, to: input.to, text: input.text, key: t.key, token: t.token })
+  const res = await fetch(url, { method: 'POST', body, headers: { 'content-type': 'application/x-www-form-urlencoded' } })
+  if (!res.ok)
+    throw new Error(`Bing translate HTTP ${res.status}`)
+  const data = await res.json() as Array<{ translations: Array<{ text: string }> }>
+  return { text: data?.[0]?.translations?.[0]?.text ?? '' }
+}
+```
+
+**Step 4: 测试通过**
+
+Run: `SKIP_FREE_API=true pnpm test src/utils/host/translate/api/__tests__/bing.test.ts`
+Expected: PASS (2 tests)
+
+**Step 5: Commit**
+
+```bash
+git add src/utils/host/translate/api/bing.ts src/utils/host/translate/api/__tests__/bing.test.ts
+git commit -m "feat(translate): add Bing web translation provider"
+```
+
+---
+
+## Task 3: Yandex Web 翻译 provider
+
+**Files:**
+- Create: `src/utils/host/translate/api/yandex.ts`
+- Create: `src/utils/host/translate/api/__tests__/yandex.test.ts`
+
+**Step 1: 写失败测试**
+
+```ts
+// src/utils/host/translate/api/__tests__/yandex.test.ts
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { translateYandex } from '../yandex'
+
+describe('translateYandex', () => {
+  beforeEach(() => vi.restoreAllMocks())
+
+  it('returns translated text', async () => {
+    vi.stubGlobal('fetch', vi.fn()
+      .mockResolvedValueOnce({ ok: true, text: async () => 'SID: "abc.def"' })
+      .mockResolvedValueOnce({ ok: true, json: async () => ({ code: 200, text: ['bonjour'] }) }))
+    await expect(translateYandex({ text: 'hello', from: 'en', to: 'fr' }))
+      .resolves.toEqual({ text: 'bonjour' })
+  })
+
+  it('throws on Yandex error code', async () => {
+    vi.stubGlobal('fetch', vi.fn()
+      .mockResolvedValueOnce({ ok: true, text: async () => 'SID: "abc.def"' })
+      .mockResolvedValueOnce({ ok: true, json: async () => ({ code: 501, message: 'blocked' }) }))
+    await expect(translateYandex({ text: 'hi', from: 'en', to: 'fr' })).rejects.toThrow(/501/)
+  })
+})
+```
+
+**Step 2: 验证失败**
+
+Run: `SKIP_FREE_API=true pnpm test src/utils/host/translate/api/__tests__/yandex.test.ts`
+Expected: FAIL
+
+**Step 3: 最小实现**
+
+```ts
+// src/utils/host/translate/api/yandex.ts
+export interface YandexInput { text: string, from: string, to: string }
+export interface YandexOutput { text: string }
+
+let sidCache: { sid: string, fetchedAt: number } | null = null
+const TTL = 30 * 60_000
+
+async function fetchSid(): Promise<string> {
+  if (sidCache && Date.now() - sidCache.fetchedAt < TTL)
+    return sidCache.sid
+  const res = await fetch('https://translate.yandex.com/')
+  const html = await res.text()
+  const m = html.match(/SID:\s*['"]([^'"]+)['"]/)
+  if (!m)
+    throw new Error('Yandex SID not found')
+  const sid = m[1].split('.').reverse().join('.')
+  sidCache = { sid, fetchedAt: Date.now() }
+  return sid
+}
+
+export async function translateYandex(input: YandexInput): Promise<YandexOutput> {
+  const sid = await fetchSid()
+  const url = `https://translate.yandex.net/api/v1/tr.json/translate?srv=tr-text&id=${sid}-0-0&lang=${input.from}-${input.to}`
+  const body = new URLSearchParams({ text: input.text, options: '4' })
+  const res = await fetch(url, { method: 'POST', body })
+  const data = await res.json() as { code: number, text?: string[], message?: string }
+  if (data.code !== 200)
+    throw new Error(`Yandex translate error ${data.code}: ${data.message ?? ''}`)
+  return { text: data.text?.[0] ?? '' }
+}
+```
+
+**Step 4: 测试通过**
+
+Run: `SKIP_FREE_API=true pnpm test src/utils/host/translate/api/__tests__/yandex.test.ts`
+Expected: PASS
+
+**Step 5: Commit**
+
+```bash
+git add src/utils/host/translate/api/yandex.ts src/utils/host/translate/api/__tests__/yandex.test.ts
+git commit -m "feat(translate): add Yandex web translation provider"
+```
+
+---
+
+## Task 4: LibreTranslate provider（可配置 endpoint）
+
+**Files:**
+- Create: `src/utils/host/translate/api/libre.ts`
+- Create: `src/utils/host/translate/api/__tests__/libre.test.ts`
+
+**Step 1: 写失败测试**
+
+```ts
+// src/utils/host/translate/api/__tests__/libre.test.ts
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { translateLibre } from '../libre'
+
+describe('translateLibre', () => {
+  beforeEach(() => vi.restoreAllMocks())
+
+  it('POSTs to configured endpoint and returns translation', async () => {
+    const fetchMock = vi.fn().mockResolvedValue({ ok: true, json: async () => ({ translatedText: 'hola' }) })
+    vi.stubGlobal('fetch', fetchMock)
+    const out = await translateLibre({ text: 'hi', from: 'en', to: 'es', endpoint: 'https://example.com/translate' })
+    expect(out.text).toBe('hola')
+    expect(fetchMock).toHaveBeenCalledWith(
+      'https://example.com/translate',
+      expect.objectContaining({ method: 'POST' }),
+    )
+  })
+
+  it('passes api_key when provided', async () => {
+    const fetchMock = vi.fn().mockResolvedValue({ ok: true, json: async () => ({ translatedText: 'x' }) })
+    vi.stubGlobal('fetch', fetchMock)
+    await translateLibre({ text: 'a', from: 'en', to: 'de', endpoint: 'https://e/t', apiKey: 'K' })
+    const body = JSON.parse((fetchMock.mock.calls[0][1] as RequestInit).body as string)
+    expect(body.api_key).toBe('K')
+  })
+})
+```
+
+**Step 2: 验证失败**
+
+Run: `SKIP_FREE_API=true pnpm test src/utils/host/translate/api/__tests__/libre.test.ts`
+Expected: FAIL
+
+**Step 3: 最小实现**
+
+```ts
+// src/utils/host/translate/api/libre.ts
+export interface LibreInput { text: string, from: string, to: string, endpoint: string, apiKey?: string }
+export interface LibreOutput { text: string }
+
+export async function translateLibre(input: LibreInput): Promise<LibreOutput> {
+  const body: Record<string, string> = { q: input.text, source: input.from, target: input.to, format: 'text' }
+  if (input.apiKey)
+    body.api_key = input.apiKey
+  const res = await fetch(input.endpoint, {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify(body),
+  })
+  if (!res.ok)
+    throw new Error(`LibreTranslate HTTP ${res.status}`)
+  const data = await res.json() as { translatedText?: string, error?: string }
+  if (data.error)
+    throw new Error(`LibreTranslate: ${data.error}`)
+  return { text: data.translatedText ?? '' }
+}
+```
+
+**Step 4: 测试通过**
+
+Run: `SKIP_FREE_API=true pnpm test src/utils/host/translate/api/__tests__/libre.test.ts`
+Expected: PASS
+
+**Step 5: Commit**
+
+```bash
+git add src/utils/host/translate/api/libre.ts src/utils/host/translate/api/__tests__/libre.test.ts
+git commit -m "feat(translate): add LibreTranslate provider"
+```
+
+---
+
+## Task 5: 调度器集成 + 自动回退链
+
+**Files:**
+- Modify: `src/utils/host/translate/api/index.ts`（整合 health tracker + 回退顺序）
+- Create: `src/utils/host/translate/api/__tests__/dispatch.test.ts`
+
+**Step 1: 先读现有 index.ts 了解当前调度逻辑**
+
+Run: `cat src/utils/host/translate/api/index.ts`
+（Read 工具查看；注意保留原有 API 签名）
+
+**Step 2: 写失败测试（scheduler 测试）**
+
+```ts
+// src/utils/host/translate/api/__tests__/dispatch.test.ts
+import { describe, expect, it, vi } from 'vitest'
+import { dispatchFreeTranslate } from '../index'
+
+describe('dispatchFreeTranslate', () => {
+  it('falls back to next provider when first fails', async () => {
+    const google = vi.fn().mockRejectedValue(new Error('429'))
+    const bing = vi.fn().mockResolvedValue({ text: 'ok' })
+    await expect(
+      dispatchFreeTranslate(
+        { text: 'hi', from: 'en', to: 'zh-CN' },
+        { order: ['google', 'bing'], impls: { google, bing } },
+      ),
+    ).resolves.toEqual({ text: 'ok', usedProvider: 'bing' })
+  })
+
+  it('skips providers marked unhealthy', async () => {
+    const google = vi.fn()
+    const bing = vi.fn().mockResolvedValue({ text: 'ok' })
+    const health = { isHealthy: (k: string) => k !== 'google', recordFailure: vi.fn(), recordSuccess: vi.fn() }
+    await dispatchFreeTranslate(
+      { text: 'hi', from: 'en', to: 'zh-CN' },
+      { order: ['google', 'bing'], impls: { google, bing }, health },
+    )
+    expect(google).not.toHaveBeenCalled()
+  })
+})
+```
+
+**Step 3: 验证失败**
+
+Run: `SKIP_FREE_API=true pnpm test src/utils/host/translate/api/__tests__/dispatch.test.ts`
+Expected: FAIL
+
+**Step 4: 最小实现**
+
+在 `src/utils/host/translate/api/index.ts` 追加导出 `dispatchFreeTranslate`（不破坏原有导出），大致：
+
+```ts
+import type { ProviderKind } from './health'
+import { createHealthTracker } from './health'
+
+interface DispatchInput { text: string, from: string, to: string }
+interface DispatchOptions {
+  order: ProviderKind[]
+  impls: Partial<Record<ProviderKind, (i: DispatchInput) => Promise<{ text: string }>>>
+  health?: { isHealthy: (k: ProviderKind) => boolean, recordFailure: (k: ProviderKind) => void, recordSuccess: (k: ProviderKind) => void }
+}
+
+const defaultHealth = createHealthTracker()
+
+export async function dispatchFreeTranslate(input: DispatchInput, opts: DispatchOptions) {
+  const health = opts.health ?? defaultHealth
+  let lastErr: unknown
+  for (const k of opts.order) {
+    if (!health.isHealthy(k))
+      continue
+    const fn = opts.impls[k]
+    if (!fn)
+      continue
+    try {
+      const out = await fn(input)
+      health.recordSuccess(k)
+      return { ...out, usedProvider: k }
+    }
+    catch (err) {
+      health.recordFailure(k)
+      lastErr = err
+    }
+  }
+  throw lastErr ?? new Error('All free providers unhealthy')
+}
+```
+
+**Step 5: 测试通过**
+
+Run: `SKIP_FREE_API=true pnpm test src/utils/host/translate/api/__tests__/dispatch.test.ts`
+Expected: PASS
+
+**Step 6: 跑全量测试确认无回归**
+
+Run: `SKIP_FREE_API=true pnpm test`
+Expected: all pass (or unchanged failure count vs `main`)
+
+**Step 7: Type check + lint**
+
+Run: `pnpm type-check && pnpm lint`
+Expected: no errors
+
+**Step 8: Commit**
+
+```bash
+git add src/utils/host/translate/api/index.ts src/utils/host/translate/api/__tests__/dispatch.test.ts
+git commit -m "feat(translate): add multi-provider dispatch with circuit breaker fallback"
+```
+
+---
+
+## Task 6: 在 options 页面暴露新 provider 选择
+
+**Files:**
+- Modify: `src/entrypoints/options/` 内的 translate provider 设置 UI（具体文件需先读 `src/entrypoints/options/AGENTS.md`）
+- Modify: `src/utils/config/` zod schema 中 `freeProvider` 枚举，新增 `'bing' | 'yandex' | 'libre'`
+- Modify: `src/utils/config/migration-scripts/` 增加一条迁移 script，旧配置默认 `google`
+
+**Step 1: 读 config schema 找到 `freeProvider` 定义**
+
+Run Grep: `pattern: "freeProvider", type: "ts", glob: "src/utils/config/**"`
+
+**Step 2: 写迁移脚本测试 + schema 测试**
+
+参考 `src/utils/config/migration-scripts/__tests__/` 下已有迁移测试的模式，确保 `migrate(oldConfig)` 不丢字段、`freeProvider` 默认值合法。
+
+**Step 3: 扩展 schema，添加迁移**
+
+**Step 4: 改 options 页 Combobox**
+
+**Step 5: 本地跑 `pnpm dev` 肉眼验证 options 页能选中 Bing/Yandex/Libre，切换后页面翻译生效**
+
+**Step 6: Commit**
+
+```bash
+git commit -m "feat(options): expose Bing/Yandex/Libre free translation providers"
+```
+
+---
+
+## M1 验收标准
+
+- [ ] `SKIP_FREE_API=true pnpm test` 全绿，新增测试 ≥ 10 条
+- [ ] `pnpm type-check` 无错
+- [ ] `pnpm lint` 无错
+- [ ] 开发版可在 options 页切换到 Bing / Yandex / Libre 并翻译成功
+- [ ] 断网 + Google 失败模拟后自动回退到其他可用 provider
+- [ ] 连续 3 次失败后 provider 被熔断 30 秒
+- [ ] Changeset 记录加入 `.changeset/`
+
+---
+
+## 后续里程碑接入方式
+
+每个后续里程碑（M2–M6）开工前：
+
+1. 新 worktree：`git worktree add ../read-frog-m2-input-translate -b feat/input-translate`
+2. 在新 worktree 运行 `/superpowers:brainstorming`，细化需求
+3. 运行 `/superpowers:writing-plans`，产出 `docs/plans/YYYY-MM-DD-<milestone>.md`
+4. 选择执行模式（subagent-driven / parallel session）
+
+**不要**在同一个 worktree 里连续推进多个里程碑 —— 每个都走独立分支 + 独立 plan。


### PR DESCRIPTION
## Summary
- Adds `docs/plans/2026-04-20-roadmap-vs-immersive-translate.md` — M0–M6 strategic roadmap vs Immersive Translate
- Adds `docs/plans/2026-04-20-m0-commercialization.md` — detailed M0 TDD plan (8 tasks)
- Adds `docs/plans/2026-04-20-m0-issues.md` — issue drafts and batch-creation recipe
- Adds `docs/contracts/billing.md` — oRPC contract spec for the backend (`billing.*` procedures, Stripe webhook expectations)
- Removes `docs/` from `.gitignore` so this fork can track planning artifacts alongside code

## Context
Foundation for Epic #2 (M0 · Commercialization infrastructure). Nothing here touches runtime code — pure documentation. Subsequent PRs (#3 → #10) implement the plan.

## Test plan
- [x] No code changes — only `.md` + `.gitignore`
- [x] `git status` clean after commit
- [x] Docs render correctly in GitHub preview

🤖 Generated with [Claude Code](https://claude.com/claude-code)