### PR TITLE
feat(types): add entitlements schema and predicates

### DIFF
--- a/.changeset/m0-entitlements-schema.md
+++ b/.changeset/m0-entitlements-schema.md
@@ -1,0 +1,5 @@
+---
+"@read-frog/extension": patch
+---
+
+feat(types): add entitlements schema for upcoming billing (M0 Task 1)

--- a/.gitignore
+++ b/.gitignore
@@ -35,6 +35,7 @@ coverage/
 .turbo/
 .nx/
 .claude/worktrees/
+.omc/
 
 tsconfig.local.json
 

--- a/docs/contracts/billing.md
+++ b/docs/contracts/billing.md
@@ -56,6 +56,7 @@ const EntitlementsSchema = z.object({
 ```
 
 **字段约定：**
+
 - `tier`：订阅层。`free` 始终可用；`pro` 有 `expiresAt`；`enterprise` 可为 `null`（座席制，后端自行续期）。
 - `features`：当前层级**已生效**的 feature list。`free` 下通常为空数组。
 - `quota`：配额桶字典，key 见 §3.2。每个桶返回本账单周期的 `used` / `limit`。
@@ -65,12 +66,12 @@ const EntitlementsSchema = z.object({
 
 ### 3.2 `QuotaBucket` keys（初版）
 
-| Key | 单位 | Free 上限 | Pro 上限 | 补充 |
-|-----|------|----------|---------|------|
-| `input_translate_daily`   | 次/天  | 50    | null (无限) | 自然日 UTC 重置 |
-| `pdf_translate_daily`     | 页/天  | 50    | null        | 自然日 UTC 重置 |
-| `vocab_count`             | 条     | 100   | null        | 生命周期累计 |
-| `ai_translate_monthly`    | 次/月  | 0     | 50_000      | 自然月 UTC 重置，仅 Pro 可用 |
+| Key                     | 单位  | Free 上限 | Pro 上限    | 补充                         |
+| ----------------------- | ----- | --------- | ----------- | ---------------------------- |
+| `input_translate_daily` | 次/天 | 50        | null (无限) | 自然日 UTC 重置              |
+| `pdf_translate_daily`   | 页/天 | 50        | null        | 自然日 UTC 重置              |
+| `vocab_count`           | 条    | 100       | null        | 生命周期累计                 |
+| `ai_translate_monthly`  | 次/月 | 0         | 50_000      | 自然月 UTC 重置，仅 Pro 可用 |
 
 > **`null` 或字段缺失** 视为"无限制"。扩展端 `hasFeature / quota` 检查需同时允许这两种表达。
 
@@ -84,14 +85,14 @@ const EntitlementsSchema = z.object({
 
 ### 4.1 `billing.getEntitlements`
 
-| 项 | 值 |
-|----|----|
-| Auth | Required |
-| Input | `{}` |
-| Output | `Entitlements` |
+| 项            | 值                    |
+| ------------- | --------------------- |
+| Auth          | Required              |
+| Input         | `{}`                  |
+| Output        | `Entitlements`        |
 | Cache-Control | `private, max-age=30` |
-| Idempotent | Yes |
-| Rate limit | 60 req / min / user |
+| Idempotent    | Yes                   |
+| Rate limit    | 60 req / min / user   |
 
 **错误：**
 | oRPC code | HTTP | 语义 |
@@ -100,6 +101,7 @@ const EntitlementsSchema = z.object({
 | `INTERNAL_SERVER_ERROR` | 500 | 不可恢复 |
 
 **扩展端行为：**
+
 - 200 → 写入 Dexie `entitlements_cache` + Jotai atom
 - 401 → 触发重新登录 UI；降级 Free
 - 5xx / 网络错误 → 读 Dexie 缓存；若无则 Free
@@ -110,15 +112,16 @@ const EntitlementsSchema = z.object({
 
 扣减指定桶的配额，原子操作。扩展在使用 Pro 功能**之前**调用，后端扣减后返回剩余额度。
 
-| 项 | 值 |
-|----|----|
-| Auth | Required |
-| Input | `{ bucket: string, amount: number, request_id: string }` |
-| Output | `{ bucket: string, remaining: number \| null, reset_at: string \| null }` |
-| Idempotent | **必须**（按 `request_id`） |
-| Rate limit | 300 req / min / user |
+| 项         | 值                                                                        |
+| ---------- | ------------------------------------------------------------------------- |
+| Auth       | Required                                                                  |
+| Input      | `{ bucket: string, amount: number, request_id: string }`                  |
+| Output     | `{ bucket: string, remaining: number \| null, reset_at: string \| null }` |
+| Idempotent | **必须**（按 `request_id`）                                               |
+| Rate limit | 300 req / min / user                                                      |
 
 **输入校验：**
+
 - `bucket` 必须在 §3.2 枚举内
 - `amount >= 1`
 - `request_id` 形如 UUID v4
@@ -132,10 +135,12 @@ const EntitlementsSchema = z.object({
 | `FORBIDDEN` | 403 | Free 用户访问仅 Pro 桶 |
 
 **幂等契约：**
+
 - 同 `(userId, request_id)` 第 2 次及以后调用，**不再扣减**，返回与第 1 次完全一致的响应（包括错误）。
 - TTL 24h。
 
 **扩展端行为：**
+
 - 成功 → 更新本地 atom 中的 `quota.<bucket>`
 - `QUOTA_EXCEEDED` → 弹 `<UpgradeDialog>`
 - 网络错误 → **不** retry（已 consumed 风险），直接报错给用户
@@ -146,21 +151,22 @@ const EntitlementsSchema = z.object({
 
 生成 Stripe Checkout 会话。扩展打开返回的 `url` 在新标签完成支付。
 
-| 项 | 值 |
-|----|----|
-| Auth | Required |
-| Input | `{ plan: 'pro_monthly' \| 'pro_yearly', successUrl: string, cancelUrl: string }` |
-| Output | `{ url: string }` |
-| Idempotent | 幂等可选（建议按 `userId + plan + 15min 窗口` 去重） |
-| Rate limit | 10 req / min / user |
+| 项         | 值                                                                               |
+| ---------- | -------------------------------------------------------------------------------- |
+| Auth       | Required                                                                         |
+| Input      | `{ plan: 'pro_monthly' \| 'pro_yearly', successUrl: string, cancelUrl: string }` |
+| Output     | `{ url: string }`                                                                |
+| Idempotent | 幂等可选（建议按 `userId + plan + 15min 窗口` 去重）                             |
+| Rate limit | 10 req / min / user                                                              |
 
 **输入约束：**
+
 - `successUrl` / `cancelUrl` 必须是 `https://readfrog.app/*` 或 `chrome-extension://*`，避免 open-redirect。后端白名单校验。
 
 **错误：**
 | oRPC code | HTTP | 语义 |
 |-----------|------|------|
-| `UNAUTHORIZED` | 401 |  |
+| `UNAUTHORIZED` | 401 | |
 | `BAD_REQUEST` | 400 | plan/URL 不合法 |
 | `PRECONDITION_FAILED` | 412 | 用户已持有活跃 Pro 订阅（改走 `createPortalSession`） |
 
@@ -170,14 +176,15 @@ const EntitlementsSchema = z.object({
 
 生成 Stripe Customer Portal 链接，已订阅用户去管理/取消。
 
-| 项 | 值 |
-|----|----|
-| Auth | Required |
-| Input | `{}` |
-| Output | `{ url: string }` |
+| 项         | 值                  |
+| ---------- | ------------------- |
+| Auth       | Required            |
+| Input      | `{}`                |
+| Output     | `{ url: string }`   |
 | Rate limit | 10 req / min / user |
 
 **错误：**
+
 - `UNAUTHORIZED` / `PRECONDITION_FAILED`（未订阅用户调用）
 
 ---
@@ -186,17 +193,18 @@ const EntitlementsSchema = z.object({
 
 后端需在 `/api/stripe/webhook` 处理以下事件，并在处理成功后写 `user_entitlements` 表。每条事件**必须按 `event.id` 幂等**（TTL 30 天）。
 
-| Stripe 事件 | 行为 |
-|-------------|------|
-| `checkout.session.completed` | 创建/激活订阅 → 写入 `tier=pro`, `features`, `expiresAt` |
-| `customer.subscription.updated` | 续费、plan 变更 → 更新 `expiresAt` / `features` |
-| `customer.subscription.deleted` | 立即到期 → `tier=free`, 清空 Pro `features` |
-| `invoice.payment_failed` | **7 天宽限期**：保留 `tier=pro` 但加 flag `in_grace_period`（扩展端可用 `quota` 或单独字段展示 banner） |
-| `invoice.payment_succeeded` | 清除宽限期 flag |
+| Stripe 事件                     | 行为                                                                                                    |
+| ------------------------------- | ------------------------------------------------------------------------------------------------------- |
+| `checkout.session.completed`    | 创建/激活订阅 → 写入 `tier=pro`, `features`, `expiresAt`                                                |
+| `customer.subscription.updated` | 续费、plan 变更 → 更新 `expiresAt` / `features`                                                         |
+| `customer.subscription.deleted` | 立即到期 → `tier=free`, 清空 Pro `features`                                                             |
+| `invoice.payment_failed`        | **7 天宽限期**：保留 `tier=pro` 但加 flag `in_grace_period`（扩展端可用 `quota` 或单独字段展示 banner） |
+| `invoice.payment_succeeded`     | 清除宽限期 flag                                                                                         |
 
 **签名校验**：所有 webhook 必须用 `STRIPE_WEBHOOK_SECRET` 验证 `Stripe-Signature` header。校验失败直接 400，不重试、不落库。
 
 **关键变量**
+
 - `STRIPE_SECRET_KEY` / `STRIPE_WEBHOOK_SECRET`：仅后端持有，严禁出现在扩展 build。本扩展的 `check-api-key-env` Vite 插件会拦截 `WXT_*_API_KEY` 泄漏，但最终 review 必须人肉确认。
 
 ---
@@ -259,6 +267,6 @@ const EntitlementsSchema = z.object({
 
 ## 9. 变更记录
 
-| 日期 | 版本 | 说明 | 作者 |
-|------|------|------|------|
+| 日期       | 版本     | 说明 | 作者                    |
+| ---------- | -------- | ---- | ----------------------- |
 | 2026-04-20 | v1 draft | 初稿 | @iannoying (via Claude) |

--- a/docs/plans/2026-04-20-m0-commercialization.md
+++ b/docs/plans/2026-04-20-m0-commercialization.md
@@ -7,6 +7,7 @@
 **Goal:** 为所有付费功能铺设基础：entitlements 契约、feature flag、paywall 组件、后端联调规范。完成后任意业务功能只需 `if (!entitlement.canUse("x")) showUpgrade()` 即可接入商业化。
 
 **Architecture:**
+
 - 复用已就绪的 `better-auth` + `oRPC` + `PostHog` 三件套
 - 后端（独立 repo）新增 `billing.*` oRPC 路由，本 repo 消费它
 - Entitlements 双写：oRPC 实时查询 + Dexie 离线缓存（断网降级）
@@ -21,30 +22,30 @@
 
 ## 已有基础设施（不要重复造轮子）
 
-| 已有 | 文件 |
-|------|------|
-| better-auth React client | `src/utils/auth/auth-client.ts` — `authClient` |
-| oRPC client + tanstack-query utils | `src/utils/orpc/client.ts` — `orpcClient`, `orpc` |
-| Background fetch proxy | `src/utils/message.ts` — `sendMessage("backgroundFetch", ...)` |
-| PostHog analytics | `src/entrypoints/background/analytics.ts` |
-| Dexie app DB | `src/utils/db/dexie/app-db.ts` |
-| Jotai atoms | `src/utils/atoms/` |
-| shadcn Dialog/Button | `src/components/ui/` |
+| 已有                               | 文件                                                           |
+| ---------------------------------- | -------------------------------------------------------------- |
+| better-auth React client           | `src/utils/auth/auth-client.ts` — `authClient`                 |
+| oRPC client + tanstack-query utils | `src/utils/orpc/client.ts` — `orpcClient`, `orpc`              |
+| Background fetch proxy             | `src/utils/message.ts` — `sendMessage("backgroundFetch", ...)` |
+| PostHog analytics                  | `src/entrypoints/background/analytics.ts`                      |
+| Dexie app DB                       | `src/utils/db/dexie/app-db.ts`                                 |
+| Jotai atoms                        | `src/utils/atoms/`                                             |
+| shadcn Dialog/Button               | `src/components/ui/`                                           |
 
 ---
 
 ## Task 清单总览（8 个 Task / 8 个 Issue / 8 个 PR）
 
-| # | Task | 输出 | 预计 |
-|---|------|------|------|
-| 1 | Entitlements 契约类型定义 | `types/entitlements.ts` + zod schema | 0.5d |
-| 2 | Dexie `entitlements_cache` 表 + migration | 新表 + 读写 helper | 0.5d |
-| 3 | `useEntitlements` hook + 离线降级 | Jotai atom + hook | 1d |
-| 4 | PostHog Feature Flag 打开 + `useFeatureFlag` | 放开 flags + hook | 0.5d |
-| 5 | `<ProGate>` / `<UpgradeDialog>` 组件 | 可复用 paywall 基元 | 1d |
-| 6 | Options 页"账户与订阅"区块 | 登录态 + 订阅状态 + 升级入口 | 1d |
-| 7 | i18n 文案 | 中英 key | 0.5d |
-| 8 | 后端契约 spec 文档 | `docs/contracts/billing.md` 交给后端 | 1d |
+| #   | Task                                         | 输出                                 | 预计 |
+| --- | -------------------------------------------- | ------------------------------------ | ---- |
+| 1   | Entitlements 契约类型定义                    | `types/entitlements.ts` + zod schema | 0.5d |
+| 2   | Dexie `entitlements_cache` 表 + migration    | 新表 + 读写 helper                   | 0.5d |
+| 3   | `useEntitlements` hook + 离线降级            | Jotai atom + hook                    | 1d   |
+| 4   | PostHog Feature Flag 打开 + `useFeatureFlag` | 放开 flags + hook                    | 0.5d |
+| 5   | `<ProGate>` / `<UpgradeDialog>` 组件         | 可复用 paywall 基元                  | 1d   |
+| 6   | Options 页"账户与订阅"区块                   | 登录态 + 订阅状态 + 升级入口         | 1d   |
+| 7   | i18n 文案                                    | 中英 key                             | 0.5d |
+| 8   | 后端契约 spec 文档                           | `docs/contracts/billing.md` 交给后端 | 1d   |
 
 总计约 **6 个工作日**，但加上 PR review + 等后端联调，现实 2 周。
 
@@ -53,6 +54,7 @@
 ## Task 1: Entitlements 契约类型定义
 
 **Files:**
+
 - Create: `src/types/entitlements.ts`
 - Create: `src/types/__tests__/entitlements.test.ts`
 
@@ -179,6 +181,7 @@ git commit -m "feat(types): add entitlements schema and predicates"
 ## Task 2: Dexie `entitlements_cache` 表 + migration
 
 **Files:**
+
 - Create: `src/utils/db/dexie/tables/entitlements-cache.ts`
 - Modify: `src/utils/db/dexie/app-db.ts`（注册新表，bump version）
 - Create: `src/utils/db/dexie/tables/__tests__/entitlements-cache.test.ts`
@@ -225,11 +228,13 @@ git commit -m "feat(db): add entitlements_cache Dexie table"
 ## Task 3: `useEntitlements` hook + 离线降级
 
 **Files:**
+
 - Create: `src/utils/atoms/entitlements.ts`
 - Create: `src/hooks/use-entitlements.ts`
 - Create: `src/hooks/__tests__/use-entitlements.test.tsx`
 
 **行为契约**：
+
 1. 优先读取 oRPC `billing.getEntitlements` 返回值 → 写入 atom + Dexie
 2. 网络失败或未登录 → 读 Dexie 缓存
 3. 两者都无 → 返回 `FREE_ENTITLEMENTS`
@@ -286,6 +291,7 @@ git commit -m "feat(hooks): add useEntitlements with offline fallback"
 **当前状态**：`analytics.ts` 第 169 行 `advanced_disable_flags: true` 明确关闭了 flags。
 
 **Files:**
+
 - Modify: `src/entrypoints/background/analytics.ts:169`（改为 `false`）
 - Create: `src/utils/message.ts` 新增 `getFeatureFlag` 消息类型（content/popup 需通过 background 查询）
 - Create: `src/hooks/use-feature-flag.ts`
@@ -296,6 +302,7 @@ git commit -m "feat(hooks): add useEntitlements with offline fallback"
 **Step 1-5:** 标准 TDD 循环
 
 **Commit:**
+
 ```bash
 git commit -m "feat(analytics): enable PostHog feature flags and expose useFeatureFlag"
 ```
@@ -305,6 +312,7 @@ git commit -m "feat(analytics): enable PostHog feature flags and expose useFeatu
 ## Task 5: `<ProGate>` / `<UpgradeDialog>` 组件
 
 **Files:**
+
 - Create: `src/components/billing/pro-gate.tsx`
 - Create: `src/components/billing/upgrade-dialog.tsx`
 - Create: `src/components/billing/__tests__/pro-gate.test.tsx`
@@ -368,10 +376,12 @@ git commit -m "feat(billing): add ProGate and UpgradeDialog components"
 ## Task 6: Options 页"账户与订阅"区块
 
 **Files:**
+
 - Create: `src/entrypoints/options/routes/account.tsx`（复用 existing options routing）
 - Modify: options 侧边栏导航加入"账户"入口
 
 **UI 内容**：
+
 - 未登录：展示"登录后享受云同步 / Pro 额度"按钮 → 跳转 `${WEBSITE_URL}/login`
 - 已登录 Free：展示 `tier: Free` + "升级到 Pro" 按钮 → 跳转 `${WEBSITE_URL}/pricing`
 - Pro：tier + expiresAt + 配额进度条 + "管理订阅"（跳 Stripe Customer Portal）
@@ -379,6 +389,7 @@ git commit -m "feat(billing): add ProGate and UpgradeDialog components"
 本 Task **不做 Stripe 集成**，只跳转到 Web 站点（Web 站点的 pricing/portal 由后端团队维护）。
 
 **Commit:**
+
 ```bash
 git commit -m "feat(options): add account and subscription section"
 ```
@@ -388,9 +399,11 @@ git commit -m "feat(options): add account and subscription section"
 ## Task 7: i18n 文案
 
 **Files:**
+
 - Modify: `src/locales/en.json` / `src/locales/zh-CN.json`（和其他已有语种）
 
 新增 key：
+
 ```
 billing.tier.free / tier.pro / tier.enterprise
 billing.upgrade.cta / upgrade.title / upgrade.description
@@ -402,6 +415,7 @@ billing.account.signIn / signOut / managePlan
 所有 `<ProGate fallback>` 和 `<UpgradeDialog>` 使用 `@wxt-dev/i18n` 的 `t()`。
 
 **Commit:**
+
 ```bash
 git commit -m "feat(i18n): add billing and paywall copy"
 ```
@@ -411,6 +425,7 @@ git commit -m "feat(i18n): add billing and paywall copy"
 ## Task 8: 后端契约 spec
 
 **Files:**
+
 - Create: `docs/contracts/billing.md`
 
 **不是代码**，是交付给后端 repo（`read-frog-monorepo` / `@read-frog/api-contract`）的规范。内容：
@@ -450,6 +465,7 @@ git commit -m "feat(i18n): add billing and paywall copy"
 ```
 
 **Commit:**
+
 ```bash
 git add docs/contracts/billing.md
 git commit -m "docs(contracts): spec billing oRPC procedures for backend"

--- a/docs/plans/2026-04-20-m0-issues.md
+++ b/docs/plans/2026-04-20-m0-issues.md
@@ -343,12 +343,14 @@ gh issue edit $EPIC_NUM --body "$(cat updated-epic-body.md)"
 ## 执行节奏
 
 **Week 1**
+
 - Day 1: Epic + Issue 1,2,4,7,8 建好；**Task 8 优先动手**（后端最早启动）
 - Day 2–3: Task 1 → 2 → 4 并行 PR
 - Day 4: Task 7 PR（小、快）
 - Day 5: Task 3 PR
 
 **Week 2**
+
 - Day 6: Task 5 PR
 - Day 7: Task 6 PR
 - Day 8–10: 后端联调 + bug fix + Changeset

--- a/docs/plans/2026-04-20-roadmap-vs-immersive-translate.md
+++ b/docs/plans/2026-04-20-roadmap-vs-immersive-translate.md
@@ -13,12 +13,12 @@
 
 ## 战略定位
 
-| 维度 | 沉浸式翻译 | Read Frog 现状 | Read Frog 目标 |
-|------|-----------|---------------|---------------|
-| 触达面 | 网页/PDF/EPUB/字幕/输入框/图片 | 网页 + YouTube 字幕 | 追平 |
-| 引擎 | DeepL/有道/腾讯/Google/AI 全家桶 | 3 免费 + 20+ AI | 补传统引擎 |
-| 学习闭环 | 基础生词本 | 精读 + TTS（无闭环） | **差异化护城河** |
-| 商业化 | Pro 订阅 + 免费额度池 | BYO-Key 开源 | 三层：免费 / Pro / Enterprise |
+| 维度     | 沉浸式翻译                       | Read Frog 现状       | Read Frog 目标                |
+| -------- | -------------------------------- | -------------------- | ----------------------------- |
+| 触达面   | 网页/PDF/EPUB/字幕/输入框/图片   | 网页 + YouTube 字幕  | 追平                          |
+| 引擎     | DeepL/有道/腾讯/Google/AI 全家桶 | 3 免费 + 20+ AI      | 补传统引擎                    |
+| 学习闭环 | 基础生词本                       | 精读 + TTS（无闭环） | **差异化护城河**              |
+| 商业化   | Pro 订阅 + 免费额度池            | BYO-Key 开源         | 三层：免费 / Pro / Enterprise |
 
 **护城河**：沉浸式翻译 = "更快更全的翻译工具"；Read Frog = "AI 语言学习伴侣"（精读 + 生词本 + Anki + 自适应解释）。**不能在引擎数量上内卷**，要在学习闭环上做深。
 
@@ -29,7 +29,9 @@
 每个 **M** 约 2–4 周 / 1 人。优先级按"用户留存 × 付费意愿 / 工程复杂度"排序。
 
 ### M0 · 商业化基础设施（2 周，先行依赖）
+
 为所有付费功能铺路。
+
 - 打通 better-auth 登录态在 extension 三端（popup/options/content）的同步
 - 后端 `@read-frog/api-contract` 新增 `billing.*` 路由：`getEntitlements`、`consumeQuota`、Stripe webhook
 - 本地 `EntitlementsContext` atom + Dexie 缓存（离线降级）
@@ -38,6 +40,7 @@
 **交付验证**：在任意功能入口加 `if (!entitlement.pro) showUpgrade()` 能正常拦截。
 
 ### M1 · 官方免费翻译引擎矩阵（2 周）⭐ 本文档详细拆解
+
 沉浸式的免费用户全靠 Google/Bing Web 接口。Read Frog 当前已有 `google.ts`/`microsoft.ts`/`deeplx.ts`，但**只有 1–2 种实现**，稳定性不足。
 
 目标：扩展 `TranslationProvider` 到 **Google Web / Microsoft Edge Auth / Bing Web / Yandex Web / LibreTranslate** 五家免费；增加健康探测 + 自动回退 + 限频熔断。
@@ -45,25 +48,32 @@
 这是免费用户的生命线，也是承载千万级调用的基础设施。详见下文 **M1 任务拆解**。
 
 ### M2 · 输入框增强翻译（1.5 周）
+
 沉浸式招牌功能。触发词如 `//en ` 自动把中文翻译为英文回填。
+
 - 通用监听器：`contenteditable`、`<textarea>`、`<input>`
 - 配置表：按域名 allowlist + 触发 token
 - 冲突处理：飞书/Slack/WeChat Web 等富文本编辑器需单独适配
 - **定价**：免费版每日 50 次；Pro 无限
 
 ### M3 · PDF 双语翻译（3 周）
+
 基于 pdf.js viewer 注入覆盖层；不解析 PDF 源文件，而是在浏览器渲染后对 text layer 分段翻译并悬浮叠加。
+
 - 复用现有段落批量翻译 pipeline
 - 支持下载"带翻译标注的 PDF"（Pro 专享）
 - **定价**：免费版水印 + 50 页/天；Pro 无水印无限制
 
 ### M4 · 字幕/视频平台扩展（2 周）
+
 从 YouTube 扩展到 Netflix / Bilibili / X(Twitter) / TED / Udemy / Coursera。
+
 - 抽象 `SubtitleAdapter` 接口，YouTube 改造成首个实现
 - 每个平台独立 content script + manifest host permission
 - 社区贡献友好：`src/entrypoints/subtitles.content/adapters/` 插件式目录
 
 ### M5 · 生词本 + Anki 闭环（3 周）⭐ 差异化核心
+
 - Dexie schema：`words` 表（word / context / translation / mastery / next_review_at）
 - 划词工具栏新增"加入生词本"按钮（复用现有 selection toolbar）
 - SM-2 遗忘曲线调度，popup 新增"今日复习"页
@@ -71,10 +81,12 @@
 - **定价**：免费版 100 词；Pro 无限 + 云同步
 
 ### M6 · 术语表 + 风格库（1 周）
+
 - 术语表：`{src, dst, context?}` 绑定到自定义 prompt，注入 `[GLOSSARY]` token
 - 显示样式模板库：下划线/模糊/遮罩/行内替换 20+ preset
 
 ### 后续（非优先）
+
 - EPUB / SRT / DOCX 文件上传翻译（M7）
 - 图片 OCR 翻译（M8，需 Vision 模型）
 - 会议实时语音翻译（M9，复杂度高）
@@ -84,27 +96,29 @@
 
 ## 商业化分层（三档）
 
-| 档位 | 功能 | 定价 |
-|------|------|------|
-| Free | 全部官方免费引擎 / 基础网页翻译 / 50 次·日输入框 / 50 页·日 PDF / 100 词生词本 | ¥0 |
-| Pro | 无限引擎调用 / 去水印 PDF 下载 / 无限输入框 / 无限生词本 + 云同步 / 所有付费 AI 引擎额度池 | ¥28/月 或 ¥198/年 |
-| Enterprise | 团队术语表共享 / SSO / 审计日志 / SLA | 按座席 |
+| 档位       | 功能                                                                                       | 定价              |
+| ---------- | ------------------------------------------------------------------------------------------ | ----------------- |
+| Free       | 全部官方免费引擎 / 基础网页翻译 / 50 次·日输入框 / 50 页·日 PDF / 100 词生词本             | ¥0                |
+| Pro        | 无限引擎调用 / 去水印 PDF 下载 / 无限输入框 / 无限生词本 + 云同步 / 所有付费 AI 引擎额度池 | ¥28/月 或 ¥198/年 |
+| Enterprise | 团队术语表共享 / SSO / 审计日志 / SLA                                                      | 按座席            |
 
 **免费额度池**（Pro 专享 AI 调用）：后端走我们自己的 key，限流 + 计费，类似沉浸式的 "BabelDOC 额度"。用 M0 的 entitlements 接口扣减。
 
 ---
 
-# M1 任务拆解（可执行 TDD 计划）
+## M1 任务拆解（可执行 TDD 计划）
 
 **M1 目标**：新增 3 个免费翻译 provider（Bing Web / Yandex Web / LibreTranslate），抽出统一 `FreeProviderHealth` 熔断层，失败自动回退。
 
 **前置阅读**：
+
 - `src/utils/host/translate/api/index.ts` — 现有免费 provider 调度器
 - `src/utils/host/translate/api/google.ts` / `microsoft.ts` — 参考实现
 - `src/utils/host/translate/api/__tests__/` — 测试惯例
 - `AGENTS.md` — Testing Notes 段落（`SKIP_FREE_API=true`）
 
 **通用约定**：
+
 - 所有新 provider 放在 `src/utils/host/translate/api/`
 - 测试放在 `src/utils/host/translate/api/__tests__/`，仿照现有 `free-api.test.ts` 的 describe 分组
 - 每个 provider 必须导出 `translate(input: TranslateInput): Promise<TranslateOutput>` 签名和 `kind: "bing" | "yandex" | "libre"` 常量
@@ -115,6 +129,7 @@
 ## Task 1: 抽取 `FreeProviderHealth` 熔断层
 
 **Files:**
+
 - Create: `src/utils/host/translate/api/health.ts`
 - Create: `src/utils/host/translate/api/__tests__/health.test.ts`
 
@@ -227,6 +242,7 @@ git commit -m "feat(translate): add FreeProviderHealth circuit breaker"
 Bing 免费翻译通过 `https://www.bing.com/ttranslatev3` 接口，需要先抓 IG/IID token。
 
 **Files:**
+
 - Create: `src/utils/host/translate/api/bing.ts`
 - Create: `src/utils/host/translate/api/__tests__/bing.test.ts`
 
@@ -315,6 +331,7 @@ git commit -m "feat(translate): add Bing web translation provider"
 ## Task 3: Yandex Web 翻译 provider
 
 **Files:**
+
 - Create: `src/utils/host/translate/api/yandex.ts`
 - Create: `src/utils/host/translate/api/__tests__/yandex.test.ts`
 
@@ -402,6 +419,7 @@ git commit -m "feat(translate): add Yandex web translation provider"
 ## Task 4: LibreTranslate provider（可配置 endpoint）
 
 **Files:**
+
 - Create: `src/utils/host/translate/api/libre.ts`
 - Create: `src/utils/host/translate/api/__tests__/libre.test.ts`
 
@@ -483,6 +501,7 @@ git commit -m "feat(translate): add LibreTranslate provider"
 ## Task 5: 调度器集成 + 自动回退链
 
 **Files:**
+
 - Modify: `src/utils/host/translate/api/index.ts`（整合 health tracker + 回退顺序）
 - Create: `src/utils/host/translate/api/__tests__/dispatch.test.ts`
 
@@ -595,6 +614,7 @@ git commit -m "feat(translate): add multi-provider dispatch with circuit breaker
 ## Task 6: 在 options 页面暴露新 provider 选择
 
 **Files:**
+
 - Modify: `src/entrypoints/options/` 内的 translate provider 设置 UI（具体文件需先读 `src/entrypoints/options/AGENTS.md`）
 - Modify: `src/utils/config/` zod schema 中 `freeProvider` 枚举，新增 `'bing' | 'yandex' | 'libre'`
 - Modify: `src/utils/config/migration-scripts/` 增加一条迁移 script，旧配置默认 `google`

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -83,7 +83,7 @@ export default antfu({
   },
 ], [
   {
-    ignores: ["**/*.md/**", ".agents/**/*", ".claude/**/*", ".codex/**/*", ".cursor/**/*"],
+    ignores: ["**/*.md/**", ".agents/**/*", ".claude/**/*", ".codex/**/*", ".cursor/**/*", ".omc/**/*"],
   },
 ]).append({
   plugins: {

--- a/src/types/__tests__/entitlements.test.ts
+++ b/src/types/__tests__/entitlements.test.ts
@@ -1,0 +1,133 @@
+import type { Entitlements } from "../entitlements"
+import { describe, expect, it } from "vitest"
+import { EntitlementsSchema, FREE_ENTITLEMENTS, hasFeature, isPro } from "../entitlements"
+
+describe("entitlementsSchema", () => {
+  it("validates a free user", () => {
+    expect(() => EntitlementsSchema.parse(FREE_ENTITLEMENTS)).not.toThrow()
+  })
+
+  it("validates a pro user with expiry and features", () => {
+    const pro: Entitlements = {
+      tier: "pro",
+      features: ["pdf_translate", "input_translate_unlimited"],
+      quota: { ai_translate_monthly: { used: 1200, limit: 50000 } },
+      expiresAt: "2027-01-01T00:00:00.000Z",
+    }
+    expect(() => EntitlementsSchema.parse(pro)).not.toThrow()
+  })
+
+  it("rejects unknown tier", () => {
+    expect(() =>
+      EntitlementsSchema.parse({ tier: "gold", features: [], quota: {}, expiresAt: null }),
+    ).toThrow()
+  })
+
+  it("rejects unknown feature key", () => {
+    expect(() =>
+      EntitlementsSchema.parse({
+        tier: "pro",
+        features: ["nonexistent_feature"],
+        quota: {},
+        expiresAt: null,
+      }),
+    ).toThrow()
+  })
+
+  it("rejects non-ISO expiresAt", () => {
+    expect(() =>
+      EntitlementsSchema.parse({
+        tier: "pro",
+        features: [],
+        quota: {},
+        expiresAt: "not a date",
+      }),
+    ).toThrow()
+  })
+
+  it("rejects negative quota usage", () => {
+    expect(() =>
+      EntitlementsSchema.parse({
+        tier: "pro",
+        features: [],
+        quota: { bucket: { used: -1, limit: 10 } },
+        expiresAt: null,
+      }),
+    ).toThrow()
+  })
+})
+
+describe("hasFeature", () => {
+  it("returns true when feature is granted", () => {
+    const e: Entitlements = {
+      tier: "pro",
+      features: ["pdf_translate"],
+      quota: {},
+      expiresAt: null,
+    }
+    expect(hasFeature(e, "pdf_translate")).toBe(true)
+  })
+
+  it("returns false when feature is not granted", () => {
+    expect(hasFeature(FREE_ENTITLEMENTS, "pdf_translate")).toBe(false)
+  })
+})
+
+describe("isPro", () => {
+  it("is false for free tier", () => {
+    expect(isPro(FREE_ENTITLEMENTS)).toBe(false)
+  })
+
+  it("is true for pro with future expiry", () => {
+    const e: Entitlements = {
+      tier: "pro",
+      features: [],
+      quota: {},
+      expiresAt: new Date(Date.now() + 86400_000).toISOString(),
+    }
+    expect(isPro(e)).toBe(true)
+  })
+
+  it("is false for pro with past expiry", () => {
+    const e: Entitlements = {
+      tier: "pro",
+      features: [],
+      quota: {},
+      expiresAt: new Date(Date.now() - 86400_000).toISOString(),
+    }
+    expect(isPro(e)).toBe(false)
+  })
+
+  it("is true for enterprise with null expiry", () => {
+    const e: Entitlements = {
+      tier: "enterprise",
+      features: [],
+      quota: {},
+      expiresAt: null,
+    }
+    expect(isPro(e)).toBe(true)
+  })
+
+  it("is false for pro with null expiry (defensive)", () => {
+    // null expiresAt on 'pro' is an invariant violation from backend;
+    // treat as not-pro rather than forever-pro.
+    const e: Entitlements = {
+      tier: "pro",
+      features: [],
+      quota: {},
+      expiresAt: null,
+    }
+    expect(isPro(e)).toBe(false)
+  })
+
+  it("accepts an injectable now() for deterministic testing", () => {
+    const frozenNow = Date.parse("2026-01-01T00:00:00.000Z")
+    const e: Entitlements = {
+      tier: "pro",
+      features: [],
+      quota: {},
+      expiresAt: "2025-12-31T00:00:00.000Z",
+    }
+    expect(isPro(e, () => frozenNow)).toBe(false)
+  })
+})

--- a/src/types/entitlements.ts
+++ b/src/types/entitlements.ts
@@ -1,0 +1,80 @@
+import { z } from "zod"
+
+/**
+ * Canonical list of all billable feature keys. Keep in sync with
+ * `docs/contracts/billing.md` §3.1 — adding a new key is non-breaking,
+ * removing or renaming is a v2 contract change.
+ */
+export const FeatureKeySchema = z.enum([
+  "pdf_translate",
+  "input_translate_unlimited",
+  "vocab_unlimited",
+  "vocab_cloud_sync",
+  "ai_translate_pool",
+  "subtitle_platforms_extended",
+  "enterprise_glossary_share",
+])
+export type FeatureKey = z.infer<typeof FeatureKeySchema>
+
+export const QuotaBucketSchema = z.object({
+  used: z.number().int().nonnegative(),
+  limit: z.number().int().nonnegative(),
+})
+export type QuotaBucket = z.infer<typeof QuotaBucketSchema>
+
+export const EntitlementTierSchema = z.enum(["free", "pro", "enterprise"])
+export type EntitlementTier = z.infer<typeof EntitlementTierSchema>
+
+/**
+ * The full billing-state envelope consumed by the extension. Served by
+ * `billing.getEntitlements` and cached offline in the `entitlements_cache`
+ * Dexie table (see Task 2).
+ */
+export const EntitlementsSchema = z.object({
+  tier: EntitlementTierSchema,
+  features: z.array(FeatureKeySchema),
+  quota: z.record(z.string(), QuotaBucketSchema),
+  expiresAt: z.string().datetime().nullable(),
+})
+export type Entitlements = z.infer<typeof EntitlementsSchema>
+
+/**
+ * True iff the entitlement envelope currently grants `feature`. Bypasses
+ * any `isPro` check because backend is the source of truth for the
+ * `features` array — if the feature is listed, treat it as granted.
+ */
+export function hasFeature(e: Entitlements, feature: FeatureKey): boolean {
+  return e.features.includes(feature)
+}
+
+/**
+ * True iff the user currently has an active paid plan. Accepts an
+ * injectable `now` for deterministic testing.
+ *
+ * Defensive stance:
+ * - `free` → always false
+ * - `pro` with `null` expiresAt → false (invariant violation from backend;
+ *   we refuse to treat it as forever-pro)
+ * - `pro` with expiresAt → strict future comparison
+ * - `enterprise` with `null` expiresAt → true (seat-based, backend-managed)
+ * - `enterprise` with expiresAt → strict future comparison
+ */
+export function isPro(e: Entitlements, now: () => number = Date.now): boolean {
+  if (e.tier === "free")
+    return false
+  if (e.expiresAt === null)
+    return e.tier === "enterprise"
+  return Date.parse(e.expiresAt) > now()
+}
+
+/**
+ * Safe default when user is anonymous, offline, or backend is unreachable.
+ * Never grants a paid feature — fail-closed by design (see
+ * `docs/contracts/billing.md` §1 "Failure safety").
+ */
+export const FREE_ENTITLEMENTS: Entitlements = {
+  tier: "free",
+  features: [],
+  quota: {},
+  expiresAt: null,
+}


### PR DESCRIPTION
## Summary
Two commits:

1. **feat(types)** — adds `src/types/entitlements.ts` (zod `EntitlementsSchema`, `FeatureKey` enum, `hasFeature()`, `isPro()`, `FREE_ENTITLEMENTS`) + 14 tests. Aligned with `docs/contracts/billing.md` §3.1.
2. **chore(lint)** — ignores `.omc/` in `eslint.config.mjs` and `.gitignore` (consistent with `.agents/`, `.claude/`, `.codex/`, `.cursor/`). Unblocks pre-push hook.

Closes #3 · Part of Epic #2 (#2)

## Test plan
- [x] `pnpm test src/types/__tests__/entitlements.test.ts` → 14/14
- [x] `pnpm type-check` → clean
- [x] `pnpm lint` → clean (full repo)
- [x] `pnpm exec nx test` → green (via pre-push hook)

## Design notes
- `isPro` is **fail-closed**: `tier: 'pro'` + `expiresAt: null` returns `false` (treated as backend invariant violation rather than forever-pro). Documented in JSDoc.
- `isPro(e, now)` accepts injectable clock so downstream tests don't need `vi.useFakeTimers`.
- `FREE_ENTITLEMENTS` is the safe default used when user is anonymous, offline, or backend is unreachable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)