### PR TITLE
feat(db): add entitlements_cache Dexie table

### DIFF
--- a/.changeset/m0-entitlements-cache.md
+++ b/.changeset/m0-entitlements-cache.md
@@ -1,0 +1,5 @@
+---
+"@read-frog/extension": patch
+---
+
+feat(db): add entitlements_cache Dexie table (M0 Task 2)

--- a/src/utils/db/dexie/__tests__/entitlements.test.ts
+++ b/src/utils/db/dexie/__tests__/entitlements.test.ts
@@ -1,0 +1,80 @@
+import type { Entitlements } from "@/types/entitlements"
+import { beforeEach, describe, expect, it, vi } from "vitest"
+import { readCachedEntitlements, writeCachedEntitlements } from "../entitlements"
+
+const getMock = vi.fn()
+const putMock = vi.fn()
+
+vi.mock("@/utils/db/dexie/db", () => ({
+  db: {
+    entitlementsCache: {
+      get: (...args: unknown[]) => getMock(...args),
+      put: (...args: unknown[]) => putMock(...args),
+    },
+  },
+}))
+
+const proEntitlements: Entitlements = {
+  tier: "pro",
+  features: ["pdf_translate"],
+  quota: { ai_translate_monthly: { used: 10, limit: 5000 } },
+  expiresAt: "2099-01-01T00:00:00.000Z",
+}
+
+describe("writeCachedEntitlements", () => {
+  beforeEach(() => {
+    getMock.mockReset()
+    putMock.mockReset()
+  })
+
+  it("puts a row keyed by userId with the provided value and a fresh Date", async () => {
+    putMock.mockResolvedValue(undefined)
+    const before = Date.now()
+    await writeCachedEntitlements("u_1", proEntitlements)
+    const after = Date.now()
+
+    expect(putMock).toHaveBeenCalledTimes(1)
+    const arg = putMock.mock.calls[0][0] as {
+      userId: string
+      value: Entitlements
+      updatedAt: Date
+    }
+    expect(arg.userId).toBe("u_1")
+    expect(arg.value).toEqual(proEntitlements)
+    expect(arg.updatedAt).toBeInstanceOf(Date)
+    const t = arg.updatedAt.getTime()
+    expect(t).toBeGreaterThanOrEqual(before)
+    expect(t).toBeLessThanOrEqual(after)
+  })
+
+  it("propagates db errors", async () => {
+    putMock.mockRejectedValue(new Error("disk full"))
+    await expect(writeCachedEntitlements("u_2", proEntitlements))
+      .rejects
+      .toThrow(/disk full/)
+  })
+})
+
+describe("readCachedEntitlements", () => {
+  beforeEach(() => {
+    getMock.mockReset()
+    putMock.mockReset()
+  })
+
+  it("returns the row when found", async () => {
+    const row = { userId: "u_1", value: proEntitlements, updatedAt: new Date() }
+    getMock.mockResolvedValue(row)
+    await expect(readCachedEntitlements("u_1")).resolves.toEqual(row)
+    expect(getMock).toHaveBeenCalledWith("u_1")
+  })
+
+  it("returns null (not undefined) when missing", async () => {
+    getMock.mockResolvedValue(undefined)
+    await expect(readCachedEntitlements("missing")).resolves.toBeNull()
+  })
+
+  it("propagates db errors", async () => {
+    getMock.mockRejectedValue(new Error("db closed"))
+    await expect(readCachedEntitlements("u_x")).rejects.toThrow(/db closed/)
+  })
+})

--- a/src/utils/db/dexie/app-db.ts
+++ b/src/utils/db/dexie/app-db.ts
@@ -5,6 +5,7 @@ import { APP_NAME } from "@/utils/constants/app"
 import AiSegmentationCache from "./tables/ai-segmentation-cache"
 import ArticleSummaryCache from "./tables/article-summary-cache"
 import BatchRequestRecord from "./tables/batch-request-record"
+import EntitlementsCache from "./tables/entitlements-cache"
 import TranslationCache from "./tables/translation-cache"
 
 export default class AppDB extends Dexie {
@@ -26,6 +27,11 @@ export default class AppDB extends Dexie {
   aiSegmentationCache!: EntityTable<
     AiSegmentationCache,
     "key"
+  >
+
+  entitlementsCache!: EntityTable<
+    EntitlementsCache,
+    "userId"
   >
 
   constructor() {
@@ -81,9 +87,31 @@ export default class AppDB extends Dexie {
         key,
         createdAt`,
     })
+    this.version(5).stores({
+      translationCache: `
+        key,
+        translation,
+        createdAt`,
+      batchRequestRecord: `
+        key,
+        createdAt,
+        originalRequestCount,
+        provider,
+        model`,
+      articleSummaryCache: `
+        key,
+        createdAt`,
+      aiSegmentationCache: `
+        key,
+        createdAt`,
+      entitlementsCache: `
+        userId,
+        updatedAt`,
+    })
     this.translationCache.mapToClass(TranslationCache)
     this.batchRequestRecord.mapToClass(BatchRequestRecord)
     this.articleSummaryCache.mapToClass(ArticleSummaryCache)
     this.aiSegmentationCache.mapToClass(AiSegmentationCache)
+    this.entitlementsCache.mapToClass(EntitlementsCache)
   }
 }

--- a/src/utils/db/dexie/entitlements.ts
+++ b/src/utils/db/dexie/entitlements.ts
@@ -1,0 +1,30 @@
+import type EntitlementsCache from "./tables/entitlements-cache"
+import type { Entitlements } from "@/types/entitlements"
+import { db } from "./db"
+
+/**
+ * Upsert the latest entitlements snapshot for `userId`. `updatedAt` is stamped
+ * by this function so callers can stay pure.
+ */
+export async function writeCachedEntitlements(
+  userId: string,
+  value: Entitlements,
+): Promise<void> {
+  await db.entitlementsCache.put({
+    userId,
+    value,
+    updatedAt: new Date(),
+  })
+}
+
+/**
+ * Read the last cached entitlements row for `userId`. Returns `null` when no
+ * row exists (so callers can branch on `null` rather than `undefined`, which
+ * is more distinguishable from `undefined`-as-missing-arg).
+ */
+export async function readCachedEntitlements(
+  userId: string,
+): Promise<EntitlementsCache | null> {
+  const row = await db.entitlementsCache.get(userId)
+  return row ?? null
+}

--- a/src/utils/db/dexie/tables/entitlements-cache.ts
+++ b/src/utils/db/dexie/tables/entitlements-cache.ts
@@ -1,0 +1,15 @@
+import type { Entitlements } from "@/types/entitlements"
+import { Entity } from "dexie"
+
+/**
+ * Offline cache of `Entitlements` keyed by `userId`. One row per user; the
+ * row is overwritten on every successful `billing.getEntitlements` response.
+ *
+ * Used as a fallback by the forthcoming `useEntitlements` hook when the
+ * backend is unreachable (see `docs/contracts/billing.md` §4.1).
+ */
+export default class EntitlementsCache extends Entity {
+  userId!: string
+  value!: Entitlements
+  updatedAt!: Date
+}


### PR DESCRIPTION
## Summary
Adds the offline cache layer for billing entitlements.

- `src/utils/db/dexie/tables/entitlements-cache.ts` — `EntitlementsCache` entity (userId / value / updatedAt)
- `src/utils/db/dexie/entitlements.ts` — `readCachedEntitlements()` / `writeCachedEntitlements()` helpers
- `src/utils/db/dexie/app-db.ts` — version(5) schema bump (append-only per project convention)
- `src/utils/db/dexie/__tests__/entitlements.test.ts` — 5 tests (mock-based, matches existing db test pattern)

Closes #4 · Part of Epic #2

## Test plan
- [x] `pnpm test src/utils/db/dexie/__tests__/entitlements.test.ts` → 5/5
- [x] `pnpm type-check` → clean
- [x] `pnpm lint` → clean (full repo, via pre-push hook)
- [x] `pnpm exec nx test` → green (pre-push)

## Design notes
- Schema is **append-only**: `version(1..4)` preserved verbatim per `src/utils/db/dexie/AGENTS.md`. Existing installs migrate forward without data loss.
- Primary key is `userId` (not a synthetic hash) — there is exactly one entitlements row per user, always overwritten.
- `value` (the full `Entitlements` JSON) is stored but **not indexed** — readers always look up by `userId`.
- `readCachedEntitlements` normalizes `undefined` → `null` so the forthcoming `useEntitlements` hook can branch cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)