### PR TITLE
feat(options): add Account & Subscription section (M0 Task 6)

### DIFF
--- a/.changeset/m0-options-account.md
+++ b/.changeset/m0-options-account.md
@@ -1,0 +1,5 @@
+---
+"@read-frog/extension": patch
+---
+
+feat(options): add Account & Subscription section (M0 Task 6)

--- a/src/entrypoints/options/app-sidebar/nav-items.ts
+++ b/src/entrypoints/options/app-sidebar/nav-items.ts
@@ -1,4 +1,5 @@
 export const ROUTE_DEFS = [
+  { path: "/account" },
   { path: "/" },
   { path: "/api-providers" },
   { path: "/custom-actions" },

--- a/src/entrypoints/options/app-sidebar/settings-nav.tsx
+++ b/src/entrypoints/options/app-sidebar/settings-nav.tsx
@@ -31,6 +31,13 @@ export function SettingsNav() {
       <SidebarGroupContent>
         <SidebarMenu>
           <SidebarMenuItem>
+            <SidebarMenuButton render={<Link to="/account" />} isActive={pathname === "/account"}>
+              <Icon icon="tabler:user-circle" />
+              <span>{i18n.t("billing.account.section")}</span>
+            </SidebarMenuButton>
+          </SidebarMenuItem>
+
+          <SidebarMenuItem>
             <SidebarMenuButton render={<Link to="/" />} isActive={pathname === "/"}>
               <Icon icon="tabler:adjustments-horizontal" />
               <span>{i18n.t("options.general.title")}</span>

--- a/src/entrypoints/options/app.tsx
+++ b/src/entrypoints/options/app.tsx
@@ -6,6 +6,7 @@ import { GeneralPage } from "./pages/general"
 
 type RoutePath = (typeof ROUTE_DEFS)[number]["path"]
 
+const AccountPage = lazy(() => import("./pages/account").then(module => ({ default: module.AccountPage })))
 const ApiProvidersPage = lazy(() => import("./pages/api-providers").then(module => ({ default: module.ApiProvidersPage })))
 const CustomActionsPage = lazy(() => import("./pages/custom-actions").then(module => ({ default: module.CustomActionsPage })))
 const TranslationPage = lazy(() => import("./pages/translation").then(module => ({ default: module.TranslationPage })))
@@ -19,6 +20,7 @@ const StatisticsPage = lazy(() => import("./pages/statistics").then(module => ({
 const ConfigPage = lazy(() => import("./pages/config").then(module => ({ default: module.ConfigPage })))
 
 const ROUTE_COMPONENTS: Record<RoutePath, ComponentType> = {
+  "/account": AccountPage,
   "/": GeneralPage,
   "/api-providers": ApiProvidersPage,
   "/custom-actions": CustomActionsPage,

--- a/src/entrypoints/options/pages/account/__tests__/index.test.tsx
+++ b/src/entrypoints/options/pages/account/__tests__/index.test.tsx
@@ -1,0 +1,170 @@
+// @vitest-environment jsdom
+import type { ReactNode } from "react"
+import type { Entitlements } from "@/types/entitlements"
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query"
+import { fireEvent, render, screen } from "@testing-library/react"
+import { createStore, Provider as JotaiProvider } from "jotai"
+import { beforeEach, describe, expect, it, vi } from "vitest"
+import { FREE_ENTITLEMENTS } from "@/types/entitlements"
+import { AccountPage } from "../index"
+
+vi.mock("../../../components/page-layout", () => ({
+  PageLayout: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+}))
+
+// ---------------------------------------------------------------------------
+// Mocks
+// ---------------------------------------------------------------------------
+
+const useSessionMock = vi.fn()
+
+vi.mock("@/utils/auth/auth-client", () => ({
+  authClient: {
+    useSession: () => useSessionMock(),
+    signOut: vi.fn().mockResolvedValue({}),
+  },
+}))
+
+const useEntitlementsMock = vi.fn()
+
+vi.mock("@/hooks/use-entitlements", () => ({
+  useEntitlements: (userId: string | null) => useEntitlementsMock(userId),
+}))
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const PRO_ENTITLEMENTS: Entitlements = {
+  tier: "pro",
+  features: ["pdf_translate", "vocab_unlimited"],
+  quota: {
+    ai_translate: { used: 50, limit: 200 },
+    vocab: { used: 10, limit: 100 },
+  },
+  expiresAt: "2099-01-01T00:00:00.000Z",
+}
+
+const EXPIRED_PRO_ENTITLEMENTS: Entitlements = {
+  tier: "pro",
+  features: [],
+  quota: {},
+  expiresAt: "2020-01-01T00:00:00.000Z",
+}
+
+function renderWithProviders(ui: ReactNode) {
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false, gcTime: 0 } },
+  })
+  const store = createStore()
+
+  return render(
+    <JotaiProvider store={store}>
+      <QueryClientProvider client={client}>{ui}</QueryClientProvider>
+    </JotaiProvider>,
+  )
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("accountPage", () => {
+  beforeEach(() => {
+    useSessionMock.mockReset()
+    useEntitlementsMock.mockReset()
+    vi.stubGlobal("open", vi.fn())
+  })
+
+  it("renders signInPrompt and no upgrade button when anonymous", () => {
+    useSessionMock.mockReturnValue({ data: null, isPending: false })
+    useEntitlementsMock.mockReturnValue({ data: FREE_ENTITLEMENTS, isLoading: false, isFromCache: false })
+
+    renderWithProviders(<AccountPage />)
+
+    expect(screen.getByText("billing.account.signInPrompt")).toBeInTheDocument()
+    expect(screen.queryByText("billing.upgrade.cta")).not.toBeInTheDocument()
+  })
+
+  it("renders skeleton while loading", () => {
+    useSessionMock.mockReturnValue({ data: { user: { id: "user-1", email: "test@example.com" } }, isPending: false })
+    useEntitlementsMock.mockReturnValue({ data: FREE_ENTITLEMENTS, isLoading: true, isFromCache: false })
+
+    renderWithProviders(<AccountPage />)
+
+    expect(document.querySelector("[data-slot='skeleton']")).toBeInTheDocument()
+  })
+
+  it("renders Free badge and upgrade CTA for free user", () => {
+    useSessionMock.mockReturnValue({ data: { user: { id: "user-1", email: "test@example.com" } }, isPending: false })
+    useEntitlementsMock.mockReturnValue({ data: FREE_ENTITLEMENTS, isLoading: false, isFromCache: false })
+
+    renderWithProviders(<AccountPage />)
+
+    expect(screen.getByText("billing.tier.free")).toBeInTheDocument()
+    expect(screen.getByText("billing.upgrade.cta")).toBeInTheDocument()
+  })
+
+  it("opens pricing URL with source=options-account when free user clicks upgrade", () => {
+    useSessionMock.mockReturnValue({ data: { user: { id: "user-1", email: "test@example.com" } }, isPending: false })
+    useEntitlementsMock.mockReturnValue({ data: FREE_ENTITLEMENTS, isLoading: false, isFromCache: false })
+
+    renderWithProviders(<AccountPage />)
+
+    fireEvent.click(screen.getByText("billing.upgrade.cta"))
+
+    expect(window.open).toHaveBeenCalledWith(
+      expect.stringContaining("source=options-account"),
+      "_blank",
+      "noopener,noreferrer",
+    )
+  })
+
+  it("renders Pro badge and expiry date and manage plan button for pro user", () => {
+    useSessionMock.mockReturnValue({ data: { user: { id: "user-1", email: "test@example.com" } }, isPending: false })
+    useEntitlementsMock.mockReturnValue({ data: PRO_ENTITLEMENTS, isLoading: false, isFromCache: false })
+
+    renderWithProviders(<AccountPage />)
+
+    expect(screen.getByText("billing.tier.pro")).toBeInTheDocument()
+    expect(screen.getByText("billing.account.managePlan")).toBeInTheDocument()
+    // expiry date should be visible
+    expect(screen.getByText(/2099/)).toBeInTheDocument()
+  })
+
+  it("renders quota progress bars for pro user", () => {
+    useSessionMock.mockReturnValue({ data: { user: { id: "user-1", email: "test@example.com" } }, isPending: false })
+    useEntitlementsMock.mockReturnValue({ data: PRO_ENTITLEMENTS, isLoading: false, isFromCache: false })
+
+    renderWithProviders(<AccountPage />)
+
+    // Two quota buckets => two progress bars
+    const progressBars = document.querySelectorAll("[data-slot='progress']")
+    expect(progressBars.length).toBe(2)
+  })
+
+  it("renders expired copy and re-up CTA when expiresAt is in the past", () => {
+    useSessionMock.mockReturnValue({ data: { user: { id: "user-1", email: "test@example.com" } }, isPending: false })
+    // Hook returns FREE_ENTITLEMENTS for expired tier (fail-closed), but
+    // we pass the raw expired entitlements to test the page's own expired-date logic
+    useEntitlementsMock.mockReturnValue({ data: EXPIRED_PRO_ENTITLEMENTS, isLoading: false, isFromCache: false })
+
+    renderWithProviders(<AccountPage />)
+
+    expect(screen.getByText("billing.expiry.expired")).toBeInTheDocument()
+    // Should also show an upgrade CTA since isPro returns false for expired
+    expect(screen.getByText("billing.upgrade.cta")).toBeInTheDocument()
+  })
+
+  it("calls authClient.signOut when sign out button is clicked", async () => {
+    const { authClient } = await import("@/utils/auth/auth-client")
+    useSessionMock.mockReturnValue({ data: { user: { id: "user-1", email: "test@example.com" } }, isPending: false })
+    useEntitlementsMock.mockReturnValue({ data: FREE_ENTITLEMENTS, isLoading: false, isFromCache: false })
+
+    renderWithProviders(<AccountPage />)
+
+    fireEvent.click(screen.getByText("billing.account.signOut"))
+
+    expect(authClient.signOut).toHaveBeenCalled()
+  })
+})

--- a/src/entrypoints/options/pages/account/__tests__/index.test.tsx
+++ b/src/entrypoints/options/pages/account/__tests__/index.test.tsx
@@ -43,6 +43,15 @@ vi.mock("@/utils/db/dexie/entitlements", () => ({
   readCachedEntitlements: vi.fn().mockResolvedValue(null),
 }))
 
+vi.mock("@/utils/logger", () => ({
+  logger: {
+    warn: vi.fn(),
+    error: vi.fn(),
+    info: vi.fn(),
+    debug: vi.fn(),
+  },
+}))
+
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
@@ -196,6 +205,25 @@ describe("accountPage", () => {
       expect(store.get(entitlementsAtom)).toEqual(FREE_ENTITLEMENTS)
       expect(deleteCachedEntitlements).toHaveBeenCalledWith("user-1")
     })
+  })
+
+  it("tolerates Dexie cache delete failure during sign-out", async () => {
+    const { authClient } = await import("@/utils/auth/auth-client")
+    const { deleteCachedEntitlements } = await import("@/utils/db/dexie/entitlements")
+    ;(deleteCachedEntitlements as ReturnType<typeof vi.fn>).mockRejectedValue(new Error("IndexedDB unavailable"))
+    useSessionMock.mockReturnValue({ data: { user: { id: "user-1", email: "test@example.com" } }, isPending: false })
+    useEntitlementsMock.mockReturnValue({ data: FREE_ENTITLEMENTS, isLoading: false, isFromCache: false })
+
+    const store = createStore()
+    renderWithProviders(<AccountPage />, store)
+
+    fireEvent.click(screen.getByText("billing.account.signOut"))
+
+    await waitFor(() => {
+      expect(authClient.signOut).toHaveBeenCalled()
+      expect(store.get(entitlementsAtom)).toEqual(FREE_ENTITLEMENTS)
+    })
+    // No uncaught rejection — the .catch swallows IndexedDB errors gracefully.
   })
 
   it("renders with the billing.account.section title", () => {

--- a/src/entrypoints/options/pages/account/__tests__/index.test.tsx
+++ b/src/entrypoints/options/pages/account/__tests__/index.test.tsx
@@ -2,14 +2,20 @@
 import type { ReactNode } from "react"
 import type { Entitlements } from "@/types/entitlements"
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query"
-import { fireEvent, render, screen } from "@testing-library/react"
+import { fireEvent, render, screen, waitFor } from "@testing-library/react"
 import { createStore, Provider as JotaiProvider } from "jotai"
 import { beforeEach, describe, expect, it, vi } from "vitest"
 import { FREE_ENTITLEMENTS } from "@/types/entitlements"
+import { entitlementsAtom } from "@/utils/atoms/entitlements"
 import { AccountPage } from "../index"
 
-vi.mock("../../../components/page-layout", () => ({
-  PageLayout: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+vi.mock("@/entrypoints/options/components/page-layout", () => ({
+  PageLayout: ({ children, title }: { children: ReactNode, title: React.ReactNode }) => (
+    <div>
+      <h1 data-testid="page-title">{title}</h1>
+      {children}
+    </div>
+  ),
 }))
 
 // ---------------------------------------------------------------------------
@@ -29,6 +35,12 @@ const useEntitlementsMock = vi.fn()
 
 vi.mock("@/hooks/use-entitlements", () => ({
   useEntitlements: (userId: string | null) => useEntitlementsMock(userId),
+}))
+
+vi.mock("@/utils/db/dexie/entitlements", () => ({
+  deleteCachedEntitlements: vi.fn().mockResolvedValue(undefined),
+  writeCachedEntitlements: vi.fn().mockResolvedValue(undefined),
+  readCachedEntitlements: vi.fn().mockResolvedValue(null),
 }))
 
 // ---------------------------------------------------------------------------
@@ -52,17 +64,19 @@ const EXPIRED_PRO_ENTITLEMENTS: Entitlements = {
   expiresAt: "2020-01-01T00:00:00.000Z",
 }
 
-function renderWithProviders(ui: ReactNode) {
+function renderWithProviders(ui: ReactNode, store = createStore()) {
   const client = new QueryClient({
     defaultOptions: { queries: { retry: false, gcTime: 0 } },
   })
-  const store = createStore()
 
-  return render(
-    <JotaiProvider store={store}>
-      <QueryClientProvider client={client}>{ui}</QueryClientProvider>
-    </JotaiProvider>,
-  )
+  return {
+    store,
+    ...render(
+      <JotaiProvider store={store}>
+        <QueryClientProvider client={client}>{ui}</QueryClientProvider>
+      </JotaiProvider>,
+    ),
+  }
 }
 
 // ---------------------------------------------------------------------------
@@ -84,6 +98,16 @@ describe("accountPage", () => {
 
     expect(screen.getByText("billing.account.signInPrompt")).toBeInTheDocument()
     expect(screen.queryByText("billing.upgrade.cta")).not.toBeInTheDocument()
+  })
+
+  it("renders skeleton while session.isPending (no anonymous flash)", () => {
+    useSessionMock.mockReturnValue({ data: null, isPending: true })
+    useEntitlementsMock.mockReturnValue({ data: FREE_ENTITLEMENTS, isLoading: false, isFromCache: false })
+
+    renderWithProviders(<AccountPage />)
+
+    expect(document.querySelector("[data-slot='skeleton']")).toBeInTheDocument()
+    expect(screen.queryByText("billing.account.signInPrompt")).not.toBeInTheDocument()
   })
 
   it("renders skeleton while loading", () => {
@@ -156,15 +180,30 @@ describe("accountPage", () => {
     expect(screen.getByText("billing.upgrade.cta")).toBeInTheDocument()
   })
 
-  it("calls authClient.signOut when sign out button is clicked", async () => {
+  it("calls authClient.signOut, resets entitlementsAtom, and deletes Dexie cache on sign out", async () => {
     const { authClient } = await import("@/utils/auth/auth-client")
+    const { deleteCachedEntitlements } = await import("@/utils/db/dexie/entitlements")
     useSessionMock.mockReturnValue({ data: { user: { id: "user-1", email: "test@example.com" } }, isPending: false })
+    useEntitlementsMock.mockReturnValue({ data: FREE_ENTITLEMENTS, isLoading: false, isFromCache: false })
+
+    const store = createStore()
+    renderWithProviders(<AccountPage />, store)
+
+    fireEvent.click(screen.getByText("billing.account.signOut"))
+
+    await waitFor(() => {
+      expect(authClient.signOut).toHaveBeenCalled()
+      expect(store.get(entitlementsAtom)).toEqual(FREE_ENTITLEMENTS)
+      expect(deleteCachedEntitlements).toHaveBeenCalledWith("user-1")
+    })
+  })
+
+  it("renders with the billing.account.section title", () => {
+    useSessionMock.mockReturnValue({ data: null, isPending: false })
     useEntitlementsMock.mockReturnValue({ data: FREE_ENTITLEMENTS, isLoading: false, isFromCache: false })
 
     renderWithProviders(<AccountPage />)
 
-    fireEvent.click(screen.getByText("billing.account.signOut"))
-
-    expect(authClient.signOut).toHaveBeenCalled()
+    expect(screen.getByTestId("page-title")).toHaveTextContent("billing.account.section")
   })
 })

--- a/src/entrypoints/options/pages/account/index.tsx
+++ b/src/entrypoints/options/pages/account/index.tsx
@@ -21,6 +21,7 @@ import { entitlementsAtom } from "@/utils/atoms/entitlements"
 import { authClient } from "@/utils/auth/auth-client"
 import { WEBSITE_URL } from "@/utils/constants/url"
 import { deleteCachedEntitlements } from "@/utils/db/dexie/entitlements"
+import { logger } from "@/utils/logger"
 import { PageLayout } from "../../components/page-layout"
 
 function formatExpiry(expiresAt: string): string {
@@ -72,7 +73,9 @@ export function AccountPage() {
     await authClient.signOut()
     setEntitlements(FREE_ENTITLEMENTS)
     if (currentUserId != null) {
-      await deleteCachedEntitlements(currentUserId)
+      deleteCachedEntitlements(currentUserId).catch((err) => {
+        logger.warn("[billing] cache delete failed on sign-out", err)
+      })
     }
   }
 

--- a/src/entrypoints/options/pages/account/index.tsx
+++ b/src/entrypoints/options/pages/account/index.tsx
@@ -1,0 +1,202 @@
+import { i18n } from "#i18n"
+import { Icon } from "@iconify/react"
+import { useSetAtom } from "jotai"
+import { Badge } from "@/components/ui/base-ui/badge"
+import { Button } from "@/components/ui/base-ui/button"
+import {
+  Card,
+  CardContent,
+  CardFooter,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/base-ui/card"
+import {
+  Progress,
+  ProgressLabel,
+} from "@/components/ui/base-ui/progress"
+import { Skeleton } from "@/components/ui/base-ui/skeleton"
+import { useEntitlements } from "@/hooks/use-entitlements"
+import { isPro } from "@/types/entitlements"
+import { entitlementsAtom } from "@/utils/atoms/entitlements"
+import { authClient } from "@/utils/auth/auth-client"
+import { WEBSITE_URL } from "@/utils/constants/url"
+import { PageLayout } from "../../components/page-layout"
+
+function formatExpiry(expiresAt: string): string {
+  return new Intl.DateTimeFormat(undefined, {
+    year: "numeric",
+    month: "long",
+    day: "numeric",
+  }).format(new Date(expiresAt))
+}
+
+export function AccountPage() {
+  const session = authClient.useSession()
+  const userId = session?.data?.user?.id ?? null
+  const userEmail = session?.data?.user?.email ?? ""
+  const userImage = (session?.data?.user as { image?: string } | undefined)?.image ?? null
+
+  const { data, isLoading } = useEntitlements(userId)
+  const setEntitlements = useSetAtom(entitlementsAtom)
+
+  const proActive = isPro(data)
+  const isExpired = data.expiresAt !== null && !proActive && data.tier !== "free"
+
+  function handleUpgrade() {
+    const url = new URL(`${WEBSITE_URL}/pricing`)
+    url.searchParams.set("source", "options-account")
+    window.open(url.toString(), "_blank", "noopener,noreferrer")
+  }
+
+  function handleManagePlan() {
+    window.open(`${WEBSITE_URL}/account/billing`, "_blank", "noopener,noreferrer")
+  }
+
+  async function handleSignOut() {
+    await authClient.signOut()
+    setEntitlements({ tier: "free", features: [], quota: {}, expiresAt: null })
+  }
+
+  // ── Anonymous ─────────────────────────────────────────────────────────────
+  if (userId === null) {
+    return (
+      <PageLayout title={i18n.t("billing.account.section")}>
+        <div className="mx-auto mt-8 max-w-md">
+          <Card>
+            <CardHeader>
+              <div className="flex flex-col items-center gap-3 py-4">
+                <Icon icon="tabler:user-circle" className="size-12 text-muted-foreground" />
+                <p className="text-center text-sm text-muted-foreground">
+                  {i18n.t("billing.account.signInPrompt")}
+                </p>
+              </div>
+            </CardHeader>
+            <CardFooter className="justify-center">
+              <Button
+                onClick={() => window.open(`${WEBSITE_URL}/login`, "_blank", "noopener,noreferrer")}
+              >
+                {i18n.t("billing.account.signIn")}
+              </Button>
+            </CardFooter>
+          </Card>
+        </div>
+      </PageLayout>
+    )
+  }
+
+  // ── Loading ───────────────────────────────────────────────────────────────
+  if (isLoading) {
+    return (
+      <PageLayout title={i18n.t("billing.account.section")}>
+        <div className="mx-auto mt-8 max-w-md space-y-3">
+          <Skeleton className="h-24 w-full" />
+          <Skeleton className="h-10 w-full" />
+          <Skeleton className="h-10 w-full" />
+        </div>
+      </PageLayout>
+    )
+  }
+
+  // ── Signed in (free or pro/enterprise) ────────────────────────────────────
+  const tierLabel = i18n.t(`billing.tier.${data.tier}` as Parameters<typeof i18n.t>[0])
+  const quotaEntries = Object.entries(data.quota)
+
+  return (
+    <PageLayout title={i18n.t("billing.account.section")}>
+      <div className="mx-auto mt-8 max-w-md space-y-4">
+        {/* ── Profile card ─────────────────────────────────────────── */}
+        <Card>
+          <CardHeader>
+            <div className="flex items-center gap-3">
+              {userImage
+                ? (
+                    <img
+                      src={userImage}
+                      alt={userEmail}
+                      className="size-10 rounded-full object-cover"
+                    />
+                  )
+                : (
+                    <div className="flex size-10 items-center justify-center rounded-full bg-muted">
+                      <Icon icon="tabler:user" className="size-5 text-muted-foreground" />
+                    </div>
+                  )}
+              <div className="min-w-0 flex-1">
+                <p className="truncate text-sm font-medium">{userEmail}</p>
+                <Badge variant={proActive ? "default" : "secondary"} className="mt-0.5">
+                  {tierLabel}
+                </Badge>
+              </div>
+            </div>
+          </CardHeader>
+
+          {/* ── Expiry / renewal info ─────────────────────────────── */}
+          {data.expiresAt !== null && (
+            <CardContent>
+              {isExpired
+                ? (
+                    <p className="text-sm text-destructive">
+                      {i18n.t("billing.expiry.expired")}
+                    </p>
+                  )
+                : (
+                    <p className="text-sm text-muted-foreground">
+                      {i18n.t("billing.expiry.active")}
+                      {" "}
+                      &mdash;
+                      {" "}
+                      {formatExpiry(data.expiresAt)}
+                    </p>
+                  )}
+            </CardContent>
+          )}
+        </Card>
+
+        {/* ── Quota section (pro/enterprise only) ──────────────────── */}
+        {proActive && quotaEntries.length > 0 && (
+          <Card>
+            <CardHeader>
+              <CardTitle>{i18n.t("billing.account.viewUsage")}</CardTitle>
+            </CardHeader>
+            <CardContent className="space-y-3">
+              {quotaEntries.map(([key, bucket]) => {
+                const pct = bucket.limit > 0 ? Math.min((bucket.used / bucket.limit) * 100, 100) : 100
+                const exhausted = bucket.used >= bucket.limit
+                return (
+                  <Progress key={key} value={pct} aria-label={key}>
+                    <ProgressLabel>{key}</ProgressLabel>
+                    <span className="text-muted-foreground ml-auto text-sm tabular-nums">
+                      {exhausted
+                        ? i18n.t("billing.quota.exhausted")
+                        : `${bucket.used} ${i18n.t("billing.quota.outOf")} ${bucket.limit} ${i18n.t("billing.quota.remaining")}`}
+                    </span>
+                  </Progress>
+                )
+              })}
+            </CardContent>
+          </Card>
+        )}
+
+        {/* ── Actions ──────────────────────────────────────────────── */}
+        <div className="flex flex-col gap-2">
+          {proActive
+            ? (
+                <Button onClick={handleManagePlan}>
+                  {i18n.t("billing.account.managePlan")}
+                </Button>
+              )
+            : (
+                // Show upgrade CTA for both free users and expired-pro users
+                <Button onClick={handleUpgrade}>
+                  {i18n.t("billing.upgrade.cta")}
+                </Button>
+              )}
+
+          <Button variant="outline" onClick={handleSignOut}>
+            {i18n.t("billing.account.signOut")}
+          </Button>
+        </div>
+      </div>
+    </PageLayout>
+  )
+}

--- a/src/entrypoints/options/pages/account/index.tsx
+++ b/src/entrypoints/options/pages/account/index.tsx
@@ -16,10 +16,11 @@ import {
 } from "@/components/ui/base-ui/progress"
 import { Skeleton } from "@/components/ui/base-ui/skeleton"
 import { useEntitlements } from "@/hooks/use-entitlements"
-import { isPro } from "@/types/entitlements"
+import { FREE_ENTITLEMENTS, isPro } from "@/types/entitlements"
 import { entitlementsAtom } from "@/utils/atoms/entitlements"
 import { authClient } from "@/utils/auth/auth-client"
 import { WEBSITE_URL } from "@/utils/constants/url"
+import { deleteCachedEntitlements } from "@/utils/db/dexie/entitlements"
 import { PageLayout } from "../../components/page-layout"
 
 function formatExpiry(expiresAt: string): string {
@@ -30,11 +31,25 @@ function formatExpiry(expiresAt: string): string {
   }).format(new Date(expiresAt))
 }
 
+function AccountPageSkeleton() {
+  return (
+    <PageLayout title={i18n.t("billing.account.section")}>
+      <div className="mx-auto mt-8 max-w-md space-y-3">
+        <Skeleton className="h-24 w-full" />
+        <Skeleton className="h-10 w-full" />
+        <Skeleton className="h-10 w-full" />
+      </div>
+    </PageLayout>
+  )
+}
+
 export function AccountPage() {
   const session = authClient.useSession()
+  const sessionPending = session?.isPending ?? false
   const userId = session?.data?.user?.id ?? null
   const userEmail = session?.data?.user?.email ?? ""
-  const userImage = (session?.data?.user as { image?: string } | undefined)?.image ?? null
+  const user = session?.data?.user
+  const userImage = (user != null && "image" in user && typeof user.image === "string") ? user.image : null
 
   const { data, isLoading } = useEntitlements(userId)
   const setEntitlements = useSetAtom(entitlementsAtom)
@@ -53,8 +68,17 @@ export function AccountPage() {
   }
 
   async function handleSignOut() {
+    const currentUserId = userId // capture before session clears
     await authClient.signOut()
-    setEntitlements({ tier: "free", features: [], quota: {}, expiresAt: null })
+    setEntitlements(FREE_ENTITLEMENTS)
+    if (currentUserId != null) {
+      await deleteCachedEntitlements(currentUserId)
+    }
+  }
+
+  // ── Session pending ───────────────────────────────────────────────────────
+  if (sessionPending) {
+    return <AccountPageSkeleton />
   }
 
   // ── Anonymous ─────────────────────────────────────────────────────────────
@@ -73,7 +97,7 @@ export function AccountPage() {
             </CardHeader>
             <CardFooter className="justify-center">
               <Button
-                onClick={() => window.open(`${WEBSITE_URL}/login`, "_blank", "noopener,noreferrer")}
+                onClick={() => window.open(`${WEBSITE_URL}/log-in`, "_blank", "noopener,noreferrer")}
               >
                 {i18n.t("billing.account.signIn")}
               </Button>
@@ -86,15 +110,7 @@ export function AccountPage() {
 
   // ── Loading ───────────────────────────────────────────────────────────────
   if (isLoading) {
-    return (
-      <PageLayout title={i18n.t("billing.account.section")}>
-        <div className="mx-auto mt-8 max-w-md space-y-3">
-          <Skeleton className="h-24 w-full" />
-          <Skeleton className="h-10 w-full" />
-          <Skeleton className="h-10 w-full" />
-        </div>
-      </PageLayout>
-    )
+    return <AccountPageSkeleton />
   }
 
   // ── Signed in (free or pro/enterprise) ────────────────────────────────────

--- a/src/utils/db/dexie/entitlements.ts
+++ b/src/utils/db/dexie/entitlements.ts
@@ -28,3 +28,11 @@ export async function readCachedEntitlements(
   const row = await db.entitlementsCache.get(userId)
   return row ?? null
 }
+
+/**
+ * Purge the cached entitlements row for a specific user. Use on sign-out
+ * so the previous account's billing state does not persist in IndexedDB.
+ */
+export async function deleteCachedEntitlements(userId: string): Promise<void> {
+  await db.entitlementsCache.delete(userId)
+}


### PR DESCRIPTION
## Summary

- Adds `AccountPage` at `/account` in the Options sidebar with three UI states:
  - **Anonymous**: sign-in prompt with a link to `/login`
  - **Free tier**: user avatar, Free badge, Upgrade CTA (→ `/pricing?source=options-account`)
  - **Pro/Enterprise**: tier badge, renewal date, quota progress bars, Manage Plan link; expired state shows `billing.expiry.expired` copy + re-up CTA
- Sign-out clears `entitlementsAtom` to ensure fail-closed state after logout
- Registers `/account` route in `ROUTE_DEFS`, `ROUTE_COMPONENTS`, and `SettingsNav` (top of sidebar)
- 8 unit tests covering all states and user interactions
- Changeset included (`patch`)

Closes #10

## Test plan

- [ ] `SKIP_FREE_API=true pnpm test src/entrypoints/options/pages/account` → 8 tests pass
- [ ] `pnpm type-check` → clean
- [ ] `pnpm lint` → clean
- [ ] Pre-push nx pipeline → 1088 tests pass, lint + type-check clean
- [ ] Manual: open Options page → "Account & Subscription" appears at top of sidebar
- [ ] Manual: anonymous → sign-in prompt shown
- [ ] Manual: signed-in free → Free badge + Upgrade CTA visible
- [ ] Manual: signed-in pro → Pro badge + expiry date + quota bars + Manage Plan link
- [ ] Manual: click Sign out → session cleared, page reverts to anonymous state

🤖 Generated with [Claude Code](https://claude.com/claude-code)