### PR TITLE
feat(translate): add LibreTranslate provider

### DIFF
--- a/.changeset/m1-libre.md
+++ b/.changeset/m1-libre.md
@@ -1,0 +1,5 @@
+---
+"@read-frog/extension": patch
+---
+
+feat(translate): add LibreTranslate provider (M1 Task 4)

--- a/src/utils/host/translate/api/__tests__/libre.test.ts
+++ b/src/utils/host/translate/api/__tests__/libre.test.ts
@@ -1,0 +1,107 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+import { translateLibre } from "../libre"
+
+const fetchMock = vi.fn()
+
+describe("translateLibre", () => {
+  beforeEach(() => {
+    fetchMock.mockReset()
+    vi.stubGlobal("fetch", fetchMock)
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+  })
+
+  it("posts JSON with q/source/target/format fields to configured endpoint", async () => {
+    fetchMock.mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: vi.fn().mockResolvedValue({ translatedText: "Hola" }),
+    })
+
+    await translateLibre({ text: "Hello", from: "en", to: "es", endpoint: "https://libretranslate.com/translate" })
+
+    expect(fetchMock).toHaveBeenCalledWith("https://libretranslate.com/translate", expect.objectContaining({
+      method: "POST",
+      headers: { "content-type": "application/json" },
+    }))
+
+    const [, requestInit] = fetchMock.mock.calls[0]
+    expect(JSON.parse(requestInit.body)).toEqual({
+      q: "Hello",
+      source: "en",
+      target: "es",
+      format: "text",
+    })
+  })
+
+  it("returns translatedText from response", async () => {
+    fetchMock.mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: vi.fn().mockResolvedValue({ translatedText: "Bonjour" }),
+    })
+
+    const result = await translateLibre({ text: "Hello", from: "en", to: "fr", endpoint: "https://libretranslate.com/translate" })
+
+    expect(result).toEqual({ text: "Bonjour" })
+  })
+
+  it("includes api_key in body when provided", async () => {
+    fetchMock.mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: vi.fn().mockResolvedValue({ translatedText: "Hola" }),
+    })
+
+    await translateLibre({ text: "Hello", from: "en", to: "es", endpoint: "https://libretranslate.com/translate", apiKey: "my-secret-key" })
+
+    const [, requestInit] = fetchMock.mock.calls[0]
+    expect(JSON.parse(requestInit.body)).toEqual({
+      q: "Hello",
+      source: "en",
+      target: "es",
+      format: "text",
+      api_key: "my-secret-key",
+    })
+  })
+
+  it("does NOT include api_key in body when not provided", async () => {
+    fetchMock.mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: vi.fn().mockResolvedValue({ translatedText: "Hola" }),
+    })
+
+    await translateLibre({ text: "Hello", from: "en", to: "es", endpoint: "https://libretranslate.com/translate" })
+
+    const [, requestInit] = fetchMock.mock.calls[0]
+    const parsed = JSON.parse(requestInit.body)
+    expect(parsed).not.toHaveProperty("api_key")
+  })
+
+  it("throws with status code on HTTP error", async () => {
+    fetchMock.mockResolvedValue({
+      ok: false,
+      status: 429,
+      json: vi.fn().mockResolvedValue({}),
+    })
+
+    await expect(
+      translateLibre({ text: "Hello", from: "en", to: "es", endpoint: "https://libretranslate.com/translate" }),
+    ).rejects.toThrow("LibreTranslate HTTP 429")
+  })
+
+  it("throws with error message when payload contains error field", async () => {
+    fetchMock.mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: vi.fn().mockResolvedValue({ error: "Language pair not supported" }),
+    })
+
+    await expect(
+      translateLibre({ text: "Hello", from: "en", to: "xx", endpoint: "https://libretranslate.com/translate" }),
+    ).rejects.toThrow("LibreTranslate: Language pair not supported")
+  })
+})

--- a/src/utils/host/translate/api/__tests__/libre.test.ts
+++ b/src/utils/host/translate/api/__tests__/libre.test.ts
@@ -104,4 +104,30 @@ describe("translateLibre", () => {
       translateLibre({ text: "Hello", from: "en", to: "xx", endpoint: "https://libretranslate.com/translate" }),
     ).rejects.toThrow("LibreTranslate: Language pair not supported")
   })
+
+  it("throws 'invalid JSON response' when HTTP 200 body is not valid JSON", async () => {
+    fetchMock.mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: vi.fn().mockRejectedValue(new SyntaxError("Unexpected token < in JSON")),
+    })
+
+    await expect(
+      translateLibre({ text: "Hello", from: "en", to: "es", endpoint: "https://libretranslate.com/translate" }),
+    ).rejects.toThrow("LibreTranslate: invalid JSON response")
+  })
+
+  it("does NOT include api_key in body when apiKey is whitespace-only", async () => {
+    fetchMock.mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: vi.fn().mockResolvedValue({ translatedText: "Hola" }),
+    })
+
+    await translateLibre({ text: "Hello", from: "en", to: "es", endpoint: "https://libretranslate.com/translate", apiKey: "   " })
+
+    const [, requestInit] = fetchMock.mock.calls[0]
+    const parsed = JSON.parse(requestInit.body)
+    expect(parsed).not.toHaveProperty("api_key")
+  })
 })

--- a/src/utils/host/translate/api/libre.ts
+++ b/src/utils/host/translate/api/libre.ts
@@ -1,0 +1,19 @@
+export interface LibreInput { text: string, from: string, to: string, endpoint: string, apiKey?: string }
+export interface LibreOutput { text: string }
+
+export async function translateLibre(input: LibreInput): Promise<LibreOutput> {
+  const body: Record<string, string> = { q: input.text, source: input.from, target: input.to, format: "text" }
+  if (input.apiKey)
+    body.api_key = input.apiKey
+  const res = await fetch(input.endpoint, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify(body),
+  })
+  if (!res.ok)
+    throw new Error(`LibreTranslate HTTP ${res.status}`)
+  const data = await res.json() as { translatedText?: string, error?: string }
+  if (data.error)
+    throw new Error(`LibreTranslate: ${data.error}`)
+  return { text: data.translatedText ?? "" }
+}

--- a/src/utils/host/translate/api/libre.ts
+++ b/src/utils/host/translate/api/libre.ts
@@ -3,8 +3,9 @@ export interface LibreOutput { text: string }
 
 export async function translateLibre(input: LibreInput): Promise<LibreOutput> {
   const body: Record<string, string> = { q: input.text, source: input.from, target: input.to, format: "text" }
-  if (input.apiKey)
-    body.api_key = input.apiKey
+  const apiKey = input.apiKey?.trim()
+  if (apiKey)
+    body.api_key = apiKey
   const res = await fetch(input.endpoint, {
     method: "POST",
     headers: { "content-type": "application/json" },
@@ -12,7 +13,13 @@ export async function translateLibre(input: LibreInput): Promise<LibreOutput> {
   })
   if (!res.ok)
     throw new Error(`LibreTranslate HTTP ${res.status}`)
-  const data = await res.json() as { translatedText?: string, error?: string }
+  let data: { translatedText?: string, error?: string }
+  try {
+    data = await res.json()
+  }
+  catch {
+    throw new Error("LibreTranslate: invalid JSON response")
+  }
   if (data.error)
     throw new Error(`LibreTranslate: ${data.error}`)
   return { text: data.translatedText ?? "" }


### PR DESCRIPTION
## Summary

- New `translateLibre()` function in `src/utils/host/translate/api/libre.ts` — POSTs JSON (`q/source/target/format`) to a user-configured endpoint
- Optional `api_key` field included in body only when provided; no module-level cache needed
- 6 unit tests covering happy path, api_key present/absent, HTTP errors, and API-level error payloads

## Test plan

- [x] `posts JSON with q/source/target/format fields to configured endpoint`
- [x] `returns translatedText from response`
- [x] `includes api_key in body when provided`
- [x] `does NOT include api_key in body when not provided`
- [x] `throws with status code on HTTP error`
- [x] `throws with error message when payload contains error field`
- [x] Full suite: 1097 tests passed, lint clean, type-check clean

Closes #23 · Part of Epic #19

🤖 Generated with [Claude Code](https://claude.com/claude-code)