### PR TITLE
feat(translate): add Bing Web translation provider (M1 Task 2)

### DIFF
--- a/.changeset/m1-bing.md
+++ b/.changeset/m1-bing.md
@@ -1,0 +1,5 @@
+---
+"@read-frog/extension": patch
+---
+
+feat(translate): add Bing Web translation provider (M1 Task 2)

--- a/src/utils/host/translate/api/__tests__/bing.test.ts
+++ b/src/utils/host/translate/api/__tests__/bing.test.ts
@@ -103,4 +103,71 @@ describe("translateBing", () => {
       translateBing({ text: "Hello", from: "en", to: "zh-Hans" }),
     ).rejects.toThrow("Bing translate HTTP 429")
   })
+
+  it("throws with HTTP status when token page returns 429", async () => {
+    fetchMock.mockResolvedValueOnce({
+      ok: false,
+      status: 429,
+    })
+
+    await expect(
+      translateBing({ text: "Hello", from: "en", to: "zh-Hans" }),
+    ).rejects.toThrow("Bing translator page HTTP 429")
+  })
+
+  it("re-fetches token after TTL expires using injectable clock", async () => {
+    let fakeNow = 1_000_000
+    const now = () => fakeNow
+
+    fetchMock
+      // First token fetch
+      .mockResolvedValueOnce({
+        ok: true,
+        text: vi.fn().mockResolvedValue(TOKEN_HTML),
+      })
+      // First translate
+      .mockResolvedValueOnce({
+        ok: true,
+        json: vi.fn().mockResolvedValue(TRANSLATE_RESPONSE),
+      })
+      // Second token fetch (after TTL)
+      .mockResolvedValueOnce({
+        ok: true,
+        text: vi.fn().mockResolvedValue(TOKEN_HTML),
+      })
+      // Second translate
+      .mockResolvedValueOnce({
+        ok: true,
+        json: vi.fn().mockResolvedValue([{ translations: [{ text: "再见" }] }]),
+      })
+
+    await translateBing({ text: "Hello", from: "en", to: "zh-Hans" }, { now })
+
+    // Advance clock past 30-minute TTL
+    fakeNow += 31 * 60_000
+
+    const result = await translateBing({ text: "Goodbye", from: "en", to: "zh-Hans" }, { now })
+
+    expect(result).toEqual({ text: "再见" })
+    // Token page fetched twice (once per call after TTL), translate called twice = 4 total
+    expect(fetchMock).toHaveBeenCalledTimes(4)
+    expect(fetchMock.mock.calls[0][0]).toBe("https://www.bing.com/translator")
+    expect(fetchMock.mock.calls[2][0]).toBe("https://www.bing.com/translator")
+  })
+
+  it("throws on malformed translate response missing translations array", async () => {
+    fetchMock
+      .mockResolvedValueOnce({
+        ok: true,
+        text: vi.fn().mockResolvedValue(TOKEN_HTML),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: vi.fn().mockResolvedValue([{ detectedLanguage: { language: "en" } }]),
+      })
+
+    await expect(
+      translateBing({ text: "Hello", from: "en", to: "zh-Hans" }),
+    ).rejects.toThrow("Bing translate: unexpected response format")
+  })
 })

--- a/src/utils/host/translate/api/__tests__/bing.test.ts
+++ b/src/utils/host/translate/api/__tests__/bing.test.ts
@@ -1,0 +1,106 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+import { resetTokenCacheForTesting, translateBing } from "../bing"
+
+const fetchMock = vi.fn()
+
+const TOKEN_HTML = `
+  <html>
+    <script>
+      var _G = {}; _G.IID="translator.5028";
+      IG:"ABC123DEF456"
+      params_AbusePreventionHelper = [1745000000000,"tok3nV4lue",3600]
+    </script>
+  </html>
+`
+
+const TRANSLATE_RESPONSE = [
+  {
+    translations: [{ text: "你好，世界", to: "zh-Hans" }],
+  },
+]
+
+describe("translateBing", () => {
+  beforeEach(() => {
+    fetchMock.mockReset()
+    vi.stubGlobal("fetch", fetchMock)
+    resetTokenCacheForTesting()
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+    resetTokenCacheForTesting()
+  })
+
+  it("happy path: fetches token then translates and returns text", async () => {
+    fetchMock
+      .mockResolvedValueOnce({
+        ok: true,
+        text: vi.fn().mockResolvedValue(TOKEN_HTML),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: vi.fn().mockResolvedValue(TRANSLATE_RESPONSE),
+      })
+
+    const result = await translateBing({ text: "Hello, World", from: "en", to: "zh-Hans" })
+
+    expect(result).toEqual({ text: "你好，世界" })
+    expect(fetchMock).toHaveBeenCalledTimes(2)
+    expect(fetchMock.mock.calls[0][0]).toBe("https://www.bing.com/translator")
+    expect(fetchMock.mock.calls[1][0]).toContain("ttranslatev3")
+    expect(fetchMock.mock.calls[1][0]).toContain("IG=ABC123DEF456")
+  })
+
+  it("throws when IG token is missing from translator page HTML", async () => {
+    fetchMock.mockResolvedValueOnce({
+      ok: true,
+      text: vi.fn().mockResolvedValue("<html>no tokens here</html>"),
+    })
+
+    await expect(
+      translateBing({ text: "Hello", from: "en", to: "zh-Hans" }),
+    ).rejects.toThrow(/IG/i)
+  })
+
+  it("reuses cached token within TTL without re-fetching translator page", async () => {
+    fetchMock
+      .mockResolvedValueOnce({
+        ok: true,
+        text: vi.fn().mockResolvedValue(TOKEN_HTML),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: vi.fn().mockResolvedValue(TRANSLATE_RESPONSE),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: vi.fn().mockResolvedValue([{ translations: [{ text: "再见" }] }]),
+      })
+
+    await translateBing({ text: "Hello", from: "en", to: "zh-Hans" })
+    const result = await translateBing({ text: "Goodbye", from: "en", to: "zh-Hans" })
+
+    expect(result).toEqual({ text: "再见" })
+    // Token page fetched only once; translate called twice = 3 total
+    expect(fetchMock).toHaveBeenCalledTimes(3)
+    expect(fetchMock.mock.calls[0][0]).toBe("https://www.bing.com/translator")
+    expect(fetchMock.mock.calls[1][0]).toContain("ttranslatev3")
+    expect(fetchMock.mock.calls[2][0]).toContain("ttranslatev3")
+  })
+
+  it("throws on non-ok translate response", async () => {
+    fetchMock
+      .mockResolvedValueOnce({
+        ok: true,
+        text: vi.fn().mockResolvedValue(TOKEN_HTML),
+      })
+      .mockResolvedValueOnce({
+        ok: false,
+        status: 429,
+      })
+
+    await expect(
+      translateBing({ text: "Hello", from: "en", to: "zh-Hans" }),
+    ).rejects.toThrow("Bing translate HTTP 429")
+  })
+})

--- a/src/utils/host/translate/api/bing.ts
+++ b/src/utils/host/translate/api/bing.ts
@@ -1,0 +1,59 @@
+export interface BingInput { text: string, from: string, to: string }
+export interface BingOutput { text: string }
+
+interface TokenCache {
+  ig: string
+  iid: string
+  key: string
+  token: string
+  fetchedAt: number
+}
+
+const TOKEN_TTL = 30 * 60_000
+
+let _tokenCache: TokenCache | null = null
+
+export function resetTokenCacheForTesting(): void {
+  _tokenCache = null
+}
+
+async function fetchToken(): Promise<TokenCache> {
+  if (_tokenCache && Date.now() - _tokenCache.fetchedAt < TOKEN_TTL)
+    return _tokenCache
+
+  const res = await fetch("https://www.bing.com/translator")
+  const html = await res.text()
+  const ig = html.match(/IG:"([^"]+)"/)?.[1]
+  const iid = html.match(/_G\.IID="([^"]+)"/)?.[1]
+  const params = html.match(/params_AbusePreventionHelper\s*=\s*\[(\d+),"([^"]+)"/)
+
+  if (!ig || !iid || !params)
+    throw new Error("Bing translator IG/IID/key not found")
+
+  _tokenCache = { ig, iid, key: params[1], token: params[2], fetchedAt: Date.now() }
+  return _tokenCache
+}
+
+export async function translateBing(input: BingInput): Promise<BingOutput> {
+  const t = await fetchToken()
+  const url = `https://www.bing.com/ttranslatev3?isVertical=1&IG=${t.ig}&IID=${t.iid}`
+  const body = new URLSearchParams({
+    fromLang: input.from,
+    to: input.to,
+    text: input.text,
+    key: t.key,
+    token: t.token,
+  })
+
+  const res = await fetch(url, {
+    method: "POST",
+    body,
+    headers: { "content-type": "application/x-www-form-urlencoded" },
+  })
+
+  if (!res.ok)
+    throw new Error(`Bing translate HTTP ${res.status}`)
+
+  const data = await res.json() as Array<{ translations: Array<{ text: string }> }>
+  return { text: data?.[0]?.translations?.[0]?.text ?? "" }
+}

--- a/src/utils/host/translate/api/bing.ts
+++ b/src/utils/host/translate/api/bing.ts
@@ -9,7 +9,12 @@ interface TokenCache {
   fetchedAt: number
 }
 
+export interface BingOptions {
+  now?: () => number
+}
+
 const TOKEN_TTL = 30 * 60_000
+const defaultNow = () => Date.now()
 
 let _tokenCache: TokenCache | null = null
 
@@ -17,11 +22,14 @@ export function resetTokenCacheForTesting(): void {
   _tokenCache = null
 }
 
-async function fetchToken(): Promise<TokenCache> {
-  if (_tokenCache && Date.now() - _tokenCache.fetchedAt < TOKEN_TTL)
+async function fetchToken(now: () => number): Promise<TokenCache> {
+  if (_tokenCache && now() - _tokenCache.fetchedAt < TOKEN_TTL)
     return _tokenCache
 
   const res = await fetch("https://www.bing.com/translator")
+  if (!res.ok)
+    throw new Error(`Bing translator page HTTP ${res.status}`)
+
   const html = await res.text()
   const ig = html.match(/IG:"([^"]+)"/)?.[1]
   const iid = html.match(/_G\.IID="([^"]+)"/)?.[1]
@@ -30,12 +38,13 @@ async function fetchToken(): Promise<TokenCache> {
   if (!ig || !iid || !params)
     throw new Error("Bing translator IG/IID/key not found")
 
-  _tokenCache = { ig, iid, key: params[1], token: params[2], fetchedAt: Date.now() }
+  _tokenCache = { ig, iid, key: params[1], token: params[2], fetchedAt: now() }
   return _tokenCache
 }
 
-export async function translateBing(input: BingInput): Promise<BingOutput> {
-  const t = await fetchToken()
+export async function translateBing(input: BingInput, opts?: BingOptions): Promise<BingOutput> {
+  const now = opts?.now ?? defaultNow
+  const t = await fetchToken(now)
   const url = `https://www.bing.com/ttranslatev3?isVertical=1&IG=${t.ig}&IID=${t.iid}`
   const body = new URLSearchParams({
     fromLang: input.from,
@@ -55,5 +64,9 @@ export async function translateBing(input: BingInput): Promise<BingOutput> {
     throw new Error(`Bing translate HTTP ${res.status}`)
 
   const data = await res.json() as Array<{ translations: Array<{ text: string }> }>
-  return { text: data?.[0]?.translations?.[0]?.text ?? "" }
+  const text = data?.[0]?.translations?.[0]?.text
+  if (text == null)
+    throw new Error("Bing translate: unexpected response format")
+
+  return { text }
 }

--- a/src/utils/host/translate/api/index.ts
+++ b/src/utils/host/translate/api/index.ts
@@ -1,4 +1,5 @@
 export { aiTranslate } from "./ai"
+export { translateBing } from "./bing"
 export { deeplTranslate } from "./deepl"
 export { deeplxTranslate } from "./deeplx"
 export { googleTranslate } from "./google"


### PR DESCRIPTION
## Summary

- Implements free Bing Web translation via `https://www.bing.com/ttranslatev3`
- Scrapes IG/IID/abuse-prevention token from the Bing translator page and caches for 30 minutes
- Exports `resetTokenCacheForTesting()` for clean test isolation (no module-level cache leaks)

## Test plan

- [x] Happy path: mocks token page + translate endpoint, returns translated text
- [x] Missing IG token: mock returns no-match HTML → throws `/IG/i`
- [x] Cache reuse: second call within TTL skips token re-fetch (3 total fetches for 2 translations)
- [x] HTTP error: non-ok translate response → throws with status code
- [x] All 1095 tests pass (`pnpm test`)
- [x] No lint errors (`pnpm lint`)
- [x] No TypeScript errors (`pnpm exec tsc --noEmit`)

Closes #21 · Part of Epic #19

🤖 Generated with [Claude Code](https://claude.com/claude-code)