### PR TITLE
feat(translate): add Yandex Web translation provider (M1 Task 3)

### DIFF
--- a/.changeset/m1-yandex.md
+++ b/.changeset/m1-yandex.md
@@ -1,0 +1,5 @@
+---
+"@read-frog/extension": patch
+---
+
+feat(translate): add Yandex Web translation provider (M1 Task 3)

--- a/src/utils/host/translate/api/__tests__/yandex.test.ts
+++ b/src/utils/host/translate/api/__tests__/yandex.test.ts
@@ -1,0 +1,88 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+import { resetSidCacheForTesting, translateYandex } from "../yandex"
+
+const fetchMock = vi.fn()
+
+describe("translateYandex", () => {
+  beforeEach(() => {
+    fetchMock.mockReset()
+    vi.stubGlobal("fetch", fetchMock)
+    resetSidCacheForTesting()
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+  })
+
+  it("fetches SID and returns translated text on happy path", async () => {
+    // First call: fetch SID page
+    fetchMock.mockResolvedValueOnce({
+      ok: true,
+      text: vi.fn().mockResolvedValue(`<html>SID: 'abc.def.ghi'</html>`),
+    })
+    // Second call: translate endpoint
+    fetchMock.mockResolvedValueOnce({
+      ok: true,
+      json: vi.fn().mockResolvedValue({ code: 200, text: ["Привет"] }),
+    })
+
+    const result = await translateYandex({ text: "Hello", from: "en", to: "ru" })
+
+    expect(result).toEqual({ text: "Привет" })
+
+    // Verify SID was reversed: 'abc.def.ghi' → 'ghi.def.abc'
+    const translateCall = fetchMock.mock.calls[1]
+    expect(translateCall[0]).toContain("id=ghi.def.abc-0-0")
+    expect(translateCall[0]).toContain("lang=en-ru")
+  })
+
+  it("throws with code in message when Yandex returns non-200 code in payload", async () => {
+    fetchMock.mockResolvedValueOnce({
+      ok: true,
+      text: vi.fn().mockResolvedValue(`SID: 'x.y.z'`),
+    })
+    fetchMock.mockResolvedValueOnce({
+      ok: true,
+      json: vi.fn().mockResolvedValue({ code: 401, message: "Unauthorized" }),
+    })
+
+    await expect(
+      translateYandex({ text: "Hi", from: "en", to: "ru" }),
+    ).rejects.toThrow("Yandex translate error 401: Unauthorized")
+  })
+
+  it("throws clearly when SID is missing from the page", async () => {
+    fetchMock.mockResolvedValueOnce({
+      ok: true,
+      text: vi.fn().mockResolvedValue("<html>no sid here</html>"),
+    })
+
+    await expect(
+      translateYandex({ text: "Hi", from: "en", to: "ru" }),
+    ).rejects.toThrow("Yandex SID not found")
+  })
+
+  it("reuses cached SID within TTL without re-fetching the page", async () => {
+    // First translate: fetches SID + translates
+    fetchMock.mockResolvedValueOnce({
+      ok: true,
+      text: vi.fn().mockResolvedValue(`SID: 'a.b.c'`),
+    })
+    fetchMock.mockResolvedValueOnce({
+      ok: true,
+      json: vi.fn().mockResolvedValue({ code: 200, text: ["one"] }),
+    })
+
+    await translateYandex({ text: "one", from: "en", to: "ru" })
+
+    // Second translate: should reuse cache, only 1 more fetch call (translate only)
+    fetchMock.mockResolvedValueOnce({
+      ok: true,
+      json: vi.fn().mockResolvedValue({ code: 200, text: ["two"] }),
+    })
+
+    await translateYandex({ text: "two", from: "en", to: "ru" })
+
+    expect(fetchMock).toHaveBeenCalledTimes(3)
+  })
+})

--- a/src/utils/host/translate/api/__tests__/yandex.test.ts
+++ b/src/utils/host/translate/api/__tests__/yandex.test.ts
@@ -85,4 +85,80 @@ describe("translateYandex", () => {
 
     expect(fetchMock).toHaveBeenCalledTimes(3)
   })
+
+  it("throws HTTP error when SID page returns non-ok status (e.g. 429)", async () => {
+    fetchMock.mockResolvedValueOnce({
+      ok: false,
+      status: 429,
+    })
+
+    await expect(
+      translateYandex({ text: "Hi", from: "en", to: "ru" }),
+    ).rejects.toThrow("Yandex page HTTP 429")
+  })
+
+  it("throws HTTP error when translate endpoint returns non-ok status (e.g. 500)", async () => {
+    fetchMock.mockResolvedValueOnce({
+      ok: true,
+      text: vi.fn().mockResolvedValue(`SID: 'a.b.c'`),
+    })
+    fetchMock.mockResolvedValueOnce({
+      ok: false,
+      status: 500,
+    })
+
+    await expect(
+      translateYandex({ text: "Hi", from: "en", to: "ru" }),
+    ).rejects.toThrow("Yandex translate HTTP 500")
+  })
+
+  it("re-fetches SID after TTL expires via injectable clock", async () => {
+    let fakeNow = 0
+    const now = () => fakeNow
+
+    // First translate: fetches SID + translates
+    fetchMock.mockResolvedValueOnce({
+      ok: true,
+      text: vi.fn().mockResolvedValue(`SID: 'a.b.c'`),
+    })
+    fetchMock.mockResolvedValueOnce({
+      ok: true,
+      json: vi.fn().mockResolvedValue({ code: 200, text: ["one"] }),
+    })
+
+    await translateYandex({ text: "one", from: "en", to: "ru" }, { now })
+
+    // Advance clock past TTL (30 minutes = 1_800_000 ms)
+    fakeNow = 31 * 60_000
+
+    // Second translate: cache expired, should re-fetch SID
+    fetchMock.mockResolvedValueOnce({
+      ok: true,
+      text: vi.fn().mockResolvedValue(`SID: 'd.e.f'`),
+    })
+    fetchMock.mockResolvedValueOnce({
+      ok: true,
+      json: vi.fn().mockResolvedValue({ code: 200, text: ["two"] }),
+    })
+
+    await translateYandex({ text: "two", from: "en", to: "ru" }, { now })
+
+    // 4 total calls: SID page + translate + SID page again + translate
+    expect(fetchMock).toHaveBeenCalledTimes(4)
+  })
+
+  it("throws on malformed translate response when text field is missing", async () => {
+    fetchMock.mockResolvedValueOnce({
+      ok: true,
+      text: vi.fn().mockResolvedValue(`SID: 'a.b.c'`),
+    })
+    fetchMock.mockResolvedValueOnce({
+      ok: true,
+      json: vi.fn().mockResolvedValue({ code: 200 }),
+    })
+
+    await expect(
+      translateYandex({ text: "Hi", from: "en", to: "ru" }),
+    ).rejects.toThrow("Yandex translate: unexpected response format")
+  })
 })

--- a/src/utils/host/translate/api/yandex.ts
+++ b/src/utils/host/translate/api/yandex.ts
@@ -1,0 +1,35 @@
+export interface YandexInput { text: string, from: string, to: string }
+export interface YandexOutput { text: string }
+
+interface SidCache { sid: string, fetchedAt: number }
+
+let sidCache: SidCache | null = null
+const TTL = 30 * 60_000
+
+export function resetSidCacheForTesting(): void {
+  sidCache = null
+}
+
+async function fetchSid(): Promise<string> {
+  if (sidCache && Date.now() - sidCache.fetchedAt < TTL)
+    return sidCache.sid
+  const res = await fetch("https://translate.yandex.com/")
+  const html = await res.text()
+  const m = html.match(/SID:\s*['"]([^'"]+)['"]/)
+  if (!m)
+    throw new Error("Yandex SID not found")
+  const sid = m[1].split(".").reverse().join(".")
+  sidCache = { sid, fetchedAt: Date.now() }
+  return sid
+}
+
+export async function translateYandex(input: YandexInput): Promise<YandexOutput> {
+  const sid = await fetchSid()
+  const url = `https://translate.yandex.net/api/v1/tr.json/translate?srv=tr-text&id=${sid}-0-0&lang=${input.from}-${input.to}`
+  const body = new URLSearchParams({ text: input.text, options: "4" })
+  const res = await fetch(url, { method: "POST", body })
+  const data = await res.json() as { code: number, text?: string[], message?: string }
+  if (data.code !== 200)
+    throw new Error(`Yandex translate error ${data.code}: ${data.message ?? ""}`)
+  return { text: data.text?.[0] ?? "" }
+}

--- a/src/utils/host/translate/api/yandex.ts
+++ b/src/utils/host/translate/api/yandex.ts
@@ -10,26 +10,37 @@ export function resetSidCacheForTesting(): void {
   sidCache = null
 }
 
-async function fetchSid(): Promise<string> {
-  if (sidCache && Date.now() - sidCache.fetchedAt < TTL)
+async function fetchSid(now: () => number): Promise<string> {
+  if (sidCache && now() - sidCache.fetchedAt < TTL)
     return sidCache.sid
   const res = await fetch("https://translate.yandex.com/")
+  if (!res.ok)
+    throw new Error(`Yandex page HTTP ${res.status}`)
   const html = await res.text()
   const m = html.match(/SID:\s*['"]([^'"]+)['"]/)
   if (!m)
     throw new Error("Yandex SID not found")
   const sid = m[1].split(".").reverse().join(".")
-  sidCache = { sid, fetchedAt: Date.now() }
+  sidCache = { sid, fetchedAt: now() }
   return sid
 }
 
-export async function translateYandex(input: YandexInput): Promise<YandexOutput> {
-  const sid = await fetchSid()
+export async function translateYandex(
+  input: YandexInput,
+  opts?: { now?: () => number },
+): Promise<YandexOutput> {
+  const now = opts?.now ?? (() => Date.now())
+  const sid = await fetchSid(now)
   const url = `https://translate.yandex.net/api/v1/tr.json/translate?srv=tr-text&id=${sid}-0-0&lang=${input.from}-${input.to}`
   const body = new URLSearchParams({ text: input.text, options: "4" })
   const res = await fetch(url, { method: "POST", body })
+  if (!res.ok)
+    throw new Error(`Yandex translate HTTP ${res.status}`)
   const data = await res.json() as { code: number, text?: string[], message?: string }
   if (data.code !== 200)
     throw new Error(`Yandex translate error ${data.code}: ${data.message ?? ""}`)
-  return { text: data.text?.[0] ?? "" }
+  const text = data.text?.[0]
+  if (text == null)
+    throw new Error("Yandex translate: unexpected response format")
+  return { text }
 }


### PR DESCRIPTION
## Summary

- Implements free Yandex web translator: scrapes SID from `translate.yandex.com`,
  reverse-dots it, POSTs to `tr.json/translate` endpoint
- Caches SID for 30 minutes; exports `resetSidCacheForTesting()` for test isolation
- Adds changeset `.changeset/m1-yandex.md`

## Test plan

- [x] Happy path: SID fetched, reversed, translate endpoint returns translated text
- [x] Yandex error code (non-200 in payload): throws with code in message
- [x] Missing SID in page throws clearly
- [x] SID cache reuse within TTL (no redundant fetch)
- [x] All 1095 tests pass, lint clean, tsc clean

Closes #22 · Part of Epic #19

🤖 Generated with [Claude Code](https://claude.com/claude-code)