### PR TITLE
feat(translate): add FreeProviderHealth circuit breaker (M1 Task 1)

### DIFF
--- a/.changeset/m1-health.md
+++ b/.changeset/m1-health.md
@@ -1,0 +1,5 @@
+---
+"@read-frog/extension": patch
+---
+
+feat(translate): add FreeProviderHealth circuit breaker (M1 Task 1)

--- a/src/utils/host/translate/api/__tests__/health.test.ts
+++ b/src/utils/host/translate/api/__tests__/health.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, it } from "vitest"
+import { createHealthTracker } from "../health"
+
+describe("createHealthTracker", () => {
+  it("marks a provider unhealthy after threshold consecutive failures within the window", () => {
+    const t = 0
+    const tracker = createHealthTracker({ now: () => t, windowMs: 60_000, threshold: 3, cooldownMs: 30_000 })
+
+    expect(tracker.isHealthy("google")).toBe(true)
+
+    tracker.recordFailure("google")
+    tracker.recordFailure("google")
+    expect(tracker.isHealthy("google")).toBe(true) // still below threshold
+
+    tracker.recordFailure("google") // hits threshold
+    expect(tracker.isHealthy("google")).toBe(false)
+  })
+
+  it("provider recovers after cooldown elapses", () => {
+    let t = 0
+    const tracker = createHealthTracker({ now: () => t, windowMs: 60_000, threshold: 3, cooldownMs: 30_000 })
+
+    tracker.recordFailure("microsoft")
+    tracker.recordFailure("microsoft")
+    tracker.recordFailure("microsoft")
+    expect(tracker.isHealthy("microsoft")).toBe(false)
+
+    t = 29_999
+    expect(tracker.isHealthy("microsoft")).toBe(false)
+
+    t = 30_000 // cooldown elapsed
+    expect(tracker.isHealthy("microsoft")).toBe(true)
+  })
+
+  it("recordSuccess resets both failure history and cooldown immediately", () => {
+    const t = 0
+    const tracker = createHealthTracker({ now: () => t, windowMs: 60_000, threshold: 3, cooldownMs: 30_000 })
+
+    tracker.recordFailure("bing")
+    tracker.recordFailure("bing")
+    tracker.recordFailure("bing")
+    expect(tracker.isHealthy("bing")).toBe(false)
+
+    tracker.recordSuccess("bing")
+    expect(tracker.isHealthy("bing")).toBe(true)
+
+    // Further failures should reset the counter from zero
+    tracker.recordFailure("bing")
+    tracker.recordFailure("bing")
+    expect(tracker.isHealthy("bing")).toBe(true)
+  })
+
+  it("old failures outside the sliding window do not count toward the threshold", () => {
+    let t = 0
+    const tracker = createHealthTracker({ now: () => t, windowMs: 60_000, threshold: 3, cooldownMs: 30_000 })
+
+    // Two failures at t=0
+    tracker.recordFailure("yandex")
+    tracker.recordFailure("yandex")
+
+    // Advance past the window
+    t = 60_001
+
+    // One fresh failure — only 1 in the window, below threshold
+    tracker.recordFailure("yandex")
+    expect(tracker.isHealthy("yandex")).toBe(true)
+
+    // Two more bring it to threshold within the window
+    tracker.recordFailure("yandex")
+    tracker.recordFailure("yandex")
+    expect(tracker.isHealthy("yandex")).toBe(false)
+  })
+})

--- a/src/utils/host/translate/api/__tests__/health.test.ts
+++ b/src/utils/host/translate/api/__tests__/health.test.ts
@@ -50,6 +50,33 @@ describe("createHealthTracker", () => {
     expect(tracker.isHealthy("bing")).toBe(true)
   })
 
+  it("single post-cooldown failure does not re-trip the breaker", () => {
+    let t = 0
+    const tracker = createHealthTracker({ now: () => t, windowMs: 60_000, threshold: 3, cooldownMs: 30_000 })
+
+    // Trip the breaker
+    tracker.recordFailure("libre")
+    tracker.recordFailure("libre")
+    tracker.recordFailure("libre")
+    expect(tracker.isHealthy("libre")).toBe(false)
+
+    // Advance past cooldown — provider recovers and failures map is cleared
+    t = 30_000
+    expect(tracker.isHealthy("libre")).toBe(true)
+
+    // One new failure after recovery should not re-trip (needs threshold=3 fresh failures)
+    tracker.recordFailure("libre")
+    expect(tracker.isHealthy("libre")).toBe(true)
+
+    // A second failure is still below threshold
+    tracker.recordFailure("libre")
+    expect(tracker.isHealthy("libre")).toBe(true)
+
+    // Third fresh failure re-trips
+    tracker.recordFailure("libre")
+    expect(tracker.isHealthy("libre")).toBe(false)
+  })
+
   it("old failures outside the sliding window do not count toward the threshold", () => {
     let t = 0
     const tracker = createHealthTracker({ now: () => t, windowMs: 60_000, threshold: 3, cooldownMs: 30_000 })

--- a/src/utils/host/translate/api/health.ts
+++ b/src/utils/host/translate/api/health.ts
@@ -1,0 +1,42 @@
+export type ProviderKind = "google" | "microsoft" | "bing" | "yandex" | "libre" | "deeplx"
+
+export interface HealthOptions {
+  now?: () => number
+  windowMs?: number
+  threshold?: number
+  cooldownMs?: number
+}
+
+export function createHealthTracker(opts: HealthOptions = {}) {
+  const now = opts.now ?? (() => Date.now())
+  const windowMs = opts.windowMs ?? 60_000
+  const threshold = opts.threshold ?? 3
+  const cooldownMs = opts.cooldownMs ?? 30_000
+  const failures = new Map<string, number[]>()
+  const blockedUntil = new Map<string, number>()
+
+  return {
+    recordFailure(k: ProviderKind) {
+      const t = now()
+      const arr = (failures.get(k) ?? []).filter(ts => t - ts < windowMs)
+      arr.push(t)
+      failures.set(k, arr)
+      if (arr.length >= threshold)
+        blockedUntil.set(k, t + cooldownMs)
+    },
+    recordSuccess(k: ProviderKind) {
+      failures.delete(k)
+      blockedUntil.delete(k)
+    },
+    isHealthy(k: ProviderKind) {
+      const until = blockedUntil.get(k)
+      if (until == null)
+        return true
+      if (now() >= until) {
+        blockedUntil.delete(k)
+        return true
+      }
+      return false
+    },
+  }
+}

--- a/src/utils/host/translate/api/health.ts
+++ b/src/utils/host/translate/api/health.ts
@@ -34,6 +34,7 @@ export function createHealthTracker(opts: HealthOptions = {}) {
         return true
       if (now() >= until) {
         blockedUntil.delete(k)
+        failures.delete(k)
         return true
       }
       return false


### PR DESCRIPTION
## Summary
Pure deterministic sliding-window + cooldown circuit breaker keyed by `ProviderKind`. Foundation for the M1 fallback scheduler (#24): callers record success/failure and check `isHealthy` before dispatching.

### New files
- `src/utils/host/translate/api/health.ts` — `createHealthTracker({ now?, windowMs?, threshold?, cooldownMs? })` + `ProviderKind` type
- `src/utils/host/translate/api/__tests__/health.test.ts` — tests covering blocked-after-threshold, recovery-after-cooldown, recordSuccess reset, sliding-window expiry

Closes #20 · Part of Epic #19

## Test plan
- [x] `pnpm test src/utils/host/translate/api/__tests__/health.test.ts` → all passing
- [x] `pnpm type-check` → clean
- [x] `pnpm lint` → clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)