### PR TITLE
feat(translate): add dispatchFreeTranslate with circuit-breaker fallback chain

### DIFF
--- a/.changeset/m1-dispatcher.md
+++ b/.changeset/m1-dispatcher.md
@@ -1,0 +1,5 @@
+---
+"@read-frog/extension": patch
+---
+
+feat(translate): dispatcher with circuit-breaker fallback chain (M1 Task 5)

--- a/src/utils/host/translate/api/__tests__/dispatch.test.ts
+++ b/src/utils/host/translate/api/__tests__/dispatch.test.ts
@@ -80,16 +80,31 @@ describe("dispatchFreeTranslate", () => {
         },
         health,
       }),
-    ).rejects.toThrow("All free providers unhealthy: microsoft error")
+    ).rejects.toThrow("All free providers failed: microsoft error")
   })
 
-  it("throws immediately when order is empty", async () => {
+  it("throws 'no available' when order is empty", async () => {
     await expect(
       dispatchFreeTranslate(INPUT, {
         order: [],
         impls: { google: makeImpl("谷歌") },
       }),
-    ).rejects.toThrow("All free providers unhealthy")
+    ).rejects.toThrow("No available free translation provider")
+  })
+
+  it("throws 'no available' when every provider is skipped as unhealthy", async () => {
+    const health = makeHealth({ isHealthy: vi.fn().mockReturnValue(false) })
+    const google = makeImpl("谷歌")
+    const microsoft = makeImpl("微软")
+    await expect(
+      dispatchFreeTranslate(INPUT, {
+        order: ["google", "microsoft"],
+        impls: { google, microsoft },
+        health,
+      }),
+    ).rejects.toThrow("No available free translation provider")
+    expect(google).not.toHaveBeenCalled()
+    expect(microsoft).not.toHaveBeenCalled()
   })
 
   it("skips providers missing from impls without error", async () => {

--- a/src/utils/host/translate/api/__tests__/dispatch.test.ts
+++ b/src/utils/host/translate/api/__tests__/dispatch.test.ts
@@ -1,0 +1,131 @@
+import type { DispatchOptions, FreeTranslateImpl } from "../dispatch"
+import { describe, expect, it, vi } from "vitest"
+import { dispatchFreeTranslate } from "../dispatch"
+
+const INPUT = { text: "Hello", from: "en", to: "zh" }
+
+function makeHealth(overrides: Partial<DispatchOptions["health"]> = {}): Required<DispatchOptions>["health"] {
+  return {
+    isHealthy: vi.fn().mockReturnValue(true),
+    recordSuccess: vi.fn(),
+    recordFailure: vi.fn(),
+    ...overrides,
+  }
+}
+
+function makeImpl(result: string): FreeTranslateImpl {
+  return vi.fn().mockResolvedValue({ text: result })
+}
+
+function makeFailingImpl(message: string): FreeTranslateImpl {
+  return vi.fn().mockRejectedValue(new Error(message))
+}
+
+describe("dispatchFreeTranslate", () => {
+  it("falls back to second provider when first fails", async () => {
+    const health = makeHealth()
+    const result = await dispatchFreeTranslate(INPUT, {
+      order: ["google", "microsoft"],
+      impls: {
+        google: makeFailingImpl("google down"),
+        microsoft: makeImpl("你好"),
+      },
+      health,
+    })
+
+    expect(result).toEqual({ text: "你好", usedProvider: "microsoft" })
+  })
+
+  it("skips unhealthy provider without calling its impl", async () => {
+    const googleImpl = makeImpl("谷歌")
+    const microsoftImpl = makeImpl("微软")
+    const health = makeHealth({
+      isHealthy: vi.fn().mockImplementation((k: string) => k !== "google"),
+    })
+
+    const result = await dispatchFreeTranslate(INPUT, {
+      order: ["google", "microsoft"],
+      impls: { google: googleImpl, microsoft: microsoftImpl },
+      health,
+    })
+
+    expect(googleImpl).not.toHaveBeenCalled()
+    expect(result.usedProvider).toBe("microsoft")
+  })
+
+  it("calls recordSuccess on success and recordFailure on error", async () => {
+    const health = makeHealth()
+    await dispatchFreeTranslate(INPUT, {
+      order: ["google", "microsoft"],
+      impls: {
+        google: makeFailingImpl("network error"),
+        microsoft: makeImpl("你好"),
+      },
+      health,
+    })
+
+    expect(health.recordFailure).toHaveBeenCalledWith("google")
+    expect(health.recordSuccess).toHaveBeenCalledWith("microsoft")
+    expect(health.recordSuccess).not.toHaveBeenCalledWith("google")
+  })
+
+  it("throws with last error message when all providers fail", async () => {
+    const health = makeHealth()
+    await expect(
+      dispatchFreeTranslate(INPUT, {
+        order: ["google", "microsoft"],
+        impls: {
+          google: makeFailingImpl("google error"),
+          microsoft: makeFailingImpl("microsoft error"),
+        },
+        health,
+      }),
+    ).rejects.toThrow("All free providers unhealthy: microsoft error")
+  })
+
+  it("throws immediately when order is empty", async () => {
+    await expect(
+      dispatchFreeTranslate(INPUT, {
+        order: [],
+        impls: { google: makeImpl("谷歌") },
+      }),
+    ).rejects.toThrow("All free providers unhealthy")
+  })
+
+  it("skips providers missing from impls without error", async () => {
+    const health = makeHealth()
+    const result = await dispatchFreeTranslate(INPUT, {
+      order: ["google", "microsoft"],
+      impls: {
+        // google intentionally absent
+        microsoft: makeImpl("微软"),
+      },
+      health,
+    })
+
+    expect(result.usedProvider).toBe("microsoft")
+    expect(result.text).toBe("微软")
+  })
+
+  it("returns result from first healthy provider", async () => {
+    const health = makeHealth()
+    const googleImpl = makeImpl("谷歌")
+    const result = await dispatchFreeTranslate(INPUT, {
+      order: ["google", "microsoft"],
+      impls: { google: googleImpl, microsoft: makeImpl("微软") },
+      health,
+    })
+
+    expect(result).toEqual({ text: "谷歌", usedProvider: "google" })
+    expect(googleImpl).toHaveBeenCalledWith(INPUT)
+  })
+
+  it("works without health tracker provided", async () => {
+    const result = await dispatchFreeTranslate(INPUT, {
+      order: ["bing"],
+      impls: { bing: makeImpl("必应") },
+    })
+
+    expect(result).toEqual({ text: "必应", usedProvider: "bing" })
+  })
+})

--- a/src/utils/host/translate/api/dispatch.ts
+++ b/src/utils/host/translate/api/dispatch.ts
@@ -1,0 +1,83 @@
+import type { ProviderKind } from "./health"
+import { translateBing } from "./bing"
+import { googleTranslate } from "./google"
+import { createHealthTracker } from "./health"
+import { microsoftTranslate } from "./microsoft"
+import { translateYandex } from "./yandex"
+
+export interface FreeTranslateInput { text: string, from: string, to: string }
+export interface FreeTranslateOutput { text: string }
+
+export type FreeTranslateImpl = (input: FreeTranslateInput) => Promise<FreeTranslateOutput>
+
+export interface DispatchOptions {
+  order: ProviderKind[]
+  impls: Partial<Record<ProviderKind, FreeTranslateImpl>>
+  health?: {
+    isHealthy: (k: ProviderKind) => boolean
+    recordSuccess: (k: ProviderKind) => void
+    recordFailure: (k: ProviderKind) => void
+  }
+}
+
+export interface DispatchResult extends FreeTranslateOutput {
+  usedProvider: ProviderKind
+}
+
+export async function dispatchFreeTranslate(
+  input: FreeTranslateInput,
+  opts: DispatchOptions,
+): Promise<DispatchResult> {
+  let lastError: Error | undefined
+
+  for (const k of opts.order) {
+    // Skip if health tracker says unhealthy
+    if (opts.health && !opts.health.isHealthy(k))
+      continue
+
+    const impl = opts.impls[k]
+
+    // Skip if no impl registered for this provider
+    if (!impl)
+      continue
+
+    try {
+      const result = await impl(input)
+      opts.health?.recordSuccess(k)
+      return { ...result, usedProvider: k }
+    }
+    catch (err) {
+      lastError = err instanceof Error ? err : new Error(String(err))
+      opts.health?.recordFailure(k)
+    }
+  }
+
+  if (lastError) {
+    throw new Error(`All free providers unhealthy: ${lastError.message}`)
+  }
+
+  throw new Error("All free providers unhealthy")
+}
+
+// Default singleton health tracker — shared across calls; override in tests
+export const defaultHealth = createHealthTracker()
+
+const googleAdapter: FreeTranslateImpl = async (input) => {
+  const text = await googleTranslate(input.text, input.from, input.to)
+  return { text }
+}
+
+const microsoftAdapter: FreeTranslateImpl = async (input) => {
+  const text = await microsoftTranslate(input.text, input.from, input.to)
+  return { text }
+}
+
+export const defaultImpls: Partial<Record<ProviderKind, FreeTranslateImpl>> = {
+  google: googleAdapter,
+  microsoft: microsoftAdapter,
+  bing: input => translateBing(input),
+  yandex: input => translateYandex(input),
+  // libre and deeplx need runtime config — caller supplies them
+}
+
+export const DEFAULT_ORDER: ProviderKind[] = ["google", "microsoft", "bing", "yandex", "libre"]

--- a/src/utils/host/translate/api/dispatch.ts
+++ b/src/utils/host/translate/api/dispatch.ts
@@ -53,10 +53,10 @@ export async function dispatchFreeTranslate(
   }
 
   if (lastError) {
-    throw new Error(`All free providers unhealthy: ${lastError.message}`)
+    throw new Error(`All free providers failed: ${lastError.message}`)
   }
 
-  throw new Error("All free providers unhealthy")
+  throw new Error("No available free translation provider")
 }
 
 // Default singleton health tracker — shared across calls; override in tests
@@ -80,4 +80,11 @@ export const defaultImpls: Partial<Record<ProviderKind, FreeTranslateImpl>> = {
   // libre and deeplx need runtime config — caller supplies them
 }
 
-export const DEFAULT_ORDER: ProviderKind[] = ["google", "microsoft", "bing", "yandex", "libre"]
+/**
+ * Default provider try-order for free translation.
+ *
+ * LibreTranslate and DeepLX require runtime configuration (endpoint / api key)
+ * and must be explicitly added by the caller when configured, e.g.
+ * `[...DEFAULT_ORDER, 'libre']` after injecting `libre` into impls.
+ */
+export const DEFAULT_ORDER: ProviderKind[] = ["google", "microsoft", "bing", "yandex"]

--- a/src/utils/host/translate/api/index.ts
+++ b/src/utils/host/translate/api/index.ts
@@ -2,5 +2,18 @@ export { aiTranslate } from "./ai"
 export { translateBing } from "./bing"
 export { deeplTranslate } from "./deepl"
 export { deeplxTranslate } from "./deeplx"
+export {
+  DEFAULT_ORDER,
+  defaultHealth,
+  defaultImpls,
+  dispatchFreeTranslate,
+} from "./dispatch"
+export type {
+  DispatchOptions,
+  DispatchResult,
+  FreeTranslateImpl,
+  FreeTranslateInput,
+  FreeTranslateOutput,
+} from "./dispatch"
 export { googleTranslate } from "./google"
 export { microsoftTranslate } from "./microsoft"


### PR DESCRIPTION
## Summary

- Adds `dispatchFreeTranslate` in `src/utils/host/translate/api/dispatch.ts` — iterates an explicit `order` list, skips unhealthy providers via the Task 1 health tracker, falls back on error, and records success/failure signals back to the circuit breaker
- Normalises `googleTranslate` / `microsoftTranslate` (positional-args) into the shared `FreeTranslateImpl` adapter shape; `bing`, `yandex` already match the interface
- Exports `defaultImpls`, `defaultHealth`, and `DEFAULT_ORDER` as ready-to-use singletons; `libre` and `deeplx` are caller-supplied (need runtime config)

## Test plan

- [x] 8 unit tests in `dispatch.test.ts` — all providers mock-only (no real network)
  - [x] Fallback: first provider fails → second returns result, `usedProvider` is second
  - [x] Health gate: unhealthy provider skipped without calling its impl
  - [x] Success calls `recordSuccess`; failure calls `recordFailure`
  - [x] All fail → throws with last error message preserved
  - [x] Empty `order` → throws immediately
  - [x] Missing `impls[k]` → skipped silently
  - [x] First healthy provider wins
  - [x] Works without health tracker (no crash)
- [x] `pnpm type-check` clean
- [x] `pnpm lint` clean
- [x] Pre-push nx pipeline: 131 test files, 1127 tests — all passed
- [x] Existing `free-api.test.ts` network tests unchanged (still `describe.skip` pattern)

Closes #24 · Part of Epic #19

🤖 Generated with [Claude Code](https://claude.com/claude-code)